### PR TITLE
Add support for log files with full failure messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,17 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-$ python3 run_tests.py <test> <absolute path to data repository>
+usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-console-lines MAX_CONSOLE_LINES] test root_path
+
+positional arguments:
+  test                  the data test to run
+  root_path             the absolute path to the repository containing files to test
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
+  --max-console-lines MAX_CONSOLE_LINES
+                        the maximum number of lines of a failure message to print to the console
 ```
 
 The data are expected to be contained in CSV files that reside under

--- a/README.md
+++ b/README.md
@@ -5,17 +5,15 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-console-lines MAX_CONSOLE_LINES] test root_path
+usage: run_tests.py [-h] [--log-file LOG_FILE] test root_path
 
 positional arguments:
-  test                  the data test to run
-  root_path             the absolute path to the repository containing files to test
+  test                 the data test to run
+  root_path            the absolute path to the repository containing files to test
 
 optional arguments:
-  -h, --help            show this help message and exit
-  --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
-  --max-console-lines MAX_CONSOLE_LINES
-                        the maximum number of lines of a failure message to print to the console
+  -h, --help           show this help message and exit
+  --log-file LOG_FILE  the absolute path to a file that the full failure messages will be written to
 ```
 
 The data are expected to be contained in CSV files that reside under

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -28,21 +28,15 @@ class DuplicateEntries:
 
         return not has_content
 
-    def get_failure_message(self, max_examples: int = 10) -> str:
+    def get_failure_message(self) -> str:
         num_duplicates = 0
         for _, rows in self.__hash_to_row_numbers.items():
             num_duplicates += len(rows) - 1
 
         message = f"{num_duplicates} duplicate rows detected:\n"
-        count = 1
         for key, value in self.__hash_to_row.items():
             for row_number in self.__hash_to_row_numbers[key]:
                 message += f"\n\tRow {row_number}: {value}"
-                count += 1
-
-                if count > max_examples:
-                    message += f"\n\t[Truncated to {max_examples} examples]"
-                    return message
 
         return message
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -28,15 +28,21 @@ class DuplicateEntries:
 
         return not has_content
 
-    def get_failure_message(self) -> str:
+    def get_failure_message(self, max_examples: int = 10) -> str:
         num_duplicates = 0
         for _, rows in self.__hash_to_row_numbers.items():
             num_duplicates += len(rows) - 1
 
         message = f"{num_duplicates} duplicate rows detected:\n"
+        count = 0
         for key, value in self.__hash_to_row.items():
             for row_number in self.__hash_to_row_numbers[key]:
-                message += f"\n\tRow {row_number}: {value}"
+                if (max_examples >= 0) and (count >= max_examples):
+                    message += f"\n\t[Truncated to {max_examples} examples]"
+                    return message
+                else:
+                    message += f"\n\tRow {row_number}: {value}"
+                    count += 1
 
         return message
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -28,7 +28,7 @@ class DuplicateEntries:
 
         return not has_content
 
-    def get_failure_message(self, max_examples: int = 10) -> str:
+    def get_failure_message(self, max_examples: int = -1) -> str:
         num_duplicates = 0
         for _, rows in self.__hash_to_row_numbers.items():
             num_duplicates += len(rows) - 1

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -1,6 +1,7 @@
 import csv
 import glob
 import os
+import traceback
 import unittest
 from typing import Iterator
 
@@ -11,6 +12,37 @@ def get_csv_files(root_path: str) -> Iterator[str]:
     for file in glob.glob(os.path.join(root_path, "[0-9]" * 4, "**", "*"), recursive=True):
         if file.lower().endswith(".csv"):
             yield file
+
+
+class TruncatedTestResult(unittest.TextTestResult):
+    log_file = None
+    max_console_lines = float("inf")
+
+    def addSubTest(self, test, subtest, outcome):
+        # If outcome is None, the subtest succeeded. Otherwise, it failed with an exception where outcome is a tuple
+        # of the form returned by sys.exc_info(): (type, value, traceback).
+        if outcome is None:
+            super().addSubTest(test, subtest, outcome)
+        else:
+            # Add the truncated message to the list of failures, but keep the original for the log file.
+            original_message = "".join(traceback.format_exception(outcome[0], outcome[1], outcome[2], 0))
+            original_message_list = original_message.splitlines()
+            extra_lines = len(original_message_list) - TruncatedTestResult.max_console_lines
+            if extra_lines > 0:
+                new_message_list = original_message_list[:TruncatedTestResult.max_console_lines]
+                new_message_list.append(f"[Truncated {extra_lines} lines]")
+                new_message = "\n".join(new_message_list)
+            else:
+                new_message = original_message
+
+            super().addSubTest(test, subtest, (outcome[0], AssertionError(new_message), outcome[2]))
+
+            if TruncatedTestResult.log_file is not None:
+                with open(TruncatedTestResult.log_file, "a") as file:
+                    file.write("======================================================================\n")
+                    file.write(f"FAIL: {subtest}\n")
+                    file.write("======================================================================\n")
+                    file.write(f"{original_message}\n\n")
 
 
 class DuplicateEntriesTest(unittest.TestCase):

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -62,5 +62,5 @@ class DuplicateEntriesTest(unittest.TestCase):
                         data_test.test(row)
 
                 short_message = data_test.get_failure_message(max_examples=10)
-                full_message = f"{data_test.get_failure_message()}"
+                full_message = data_test.get_failure_message()
                 self.__assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -14,7 +14,7 @@ def get_csv_files(root_path: str) -> Iterator[str]:
             yield file
 
 
-def _get_logger(name: str, log_file: str):
+def _get_logger(name: str, log_file: str) -> logging.Logger:
     handler = logging.FileHandler(log_file)
     handler.setFormatter(logging.Formatter("%(message)s"))
 

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -14,7 +14,7 @@ def get_csv_files(root_path: str) -> Iterator[str]:
             yield file
 
 
-def get_logger(name: str, log_file: str):
+def _get_logger(name: str, log_file: str):
     handler = logging.FileHandler(log_file)
     handler.setFormatter(logging.Formatter("%(message)s"))
 
@@ -25,7 +25,7 @@ def get_logger(name: str, log_file: str):
     return logger
 
 
-def log_failure(logger: logging.Logger, description: str, message: str):
+def _log_failure(logger: logging.Logger, description: str, message: str):
     if logger is not None:
         logger.debug("======================================================================")
         logger.debug(f"FAIL: {description}")
@@ -43,11 +43,11 @@ class DuplicateEntriesTest(unittest.TestCase):
         if DuplicateEntriesTest.log_file is None:
             self.__logger = None
         else:
-            self.__logger = get_logger("Duplicate Entries", DuplicateEntriesTest.log_file)
+            self.__logger = _get_logger("Duplicate Entries", DuplicateEntriesTest.log_file)
 
     def __assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
         if not result:
-            log_failure(self.__logger, description, full_message)
+            _log_failure(self.__logger, description, full_message)
         self.assertTrue(result, short_message)
 
     def test_duplicate_entries(self):

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -61,6 +61,6 @@ class DuplicateEntriesTest(unittest.TestCase):
                     for row in reader:
                         data_test.test(row)
 
-                short_message = data_test.get_failure_message()
-                full_message = f"{data_test.get_failure_message(max_examples=-1)}"
+                short_message = data_test.get_failure_message(max_examples=10)
+                full_message = f"{data_test.get_failure_message()}"
                 self.__assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -14,45 +14,46 @@ def get_csv_files(root_path: str) -> Iterator[str]:
             yield file
 
 
-def _get_logger(name: str, log_file: str) -> logging.Logger:
-    handler = logging.FileHandler(log_file)
-    handler.setFormatter(logging.Formatter("%(message)s"))
-
-    logger = logging.getLogger(name)
-    logger.setLevel(logging.DEBUG)
-    logger.addHandler(handler)
-
-    return logger
-
-
-def _log_failure(logger: logging.Logger, description: str, message: str):
-    if logger is not None:
-        logger.debug("======================================================================")
-        logger.debug(f"FAIL: {description}")
-        logger.debug("----------------------------------------------------------------------")
-        logger.debug(f"{message}\n")
-
-
-class DuplicateEntriesTest(unittest.TestCase):
-    root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+class TestCase(unittest.TestCase):
     log_file = None
+    root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        if DuplicateEntriesTest.log_file is None:
+        if TestCase.log_file is None:
             self.__logger = None
         else:
-            self.__logger = _get_logger("Duplicate Entries", DuplicateEntriesTest.log_file)
+            self.__logger = TestCase.__get_logger(type(self).__name__, TestCase.log_file)
 
-    def __assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
+    def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
         if not result:
-            _log_failure(self.__logger, description, full_message)
+            self._log_failure(description, full_message)
         self.assertTrue(result, short_message)
 
+    def _log_failure(self, description: str, message: str):
+        if self.__logger is not None:
+            self.__logger.debug("======================================================================")
+            self.__logger.debug(f"FAIL: {description}")
+            self.__logger.debug("----------------------------------------------------------------------")
+            self.__logger.debug(f"{message}\n")
+
+    @staticmethod
+    def __get_logger(name: str, log_file: str) -> logging.Logger:
+        handler = logging.FileHandler(log_file)
+        handler.setFormatter(logging.Formatter("%(message)s"))
+
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.DEBUG)
+        logger.addHandler(handler)
+
+        return logger
+
+
+class DuplicateEntriesTest(TestCase):
     def test_duplicate_entries(self):
-        for csv_file in get_csv_files(DuplicateEntriesTest.root_path):
-            short_path = os.path.relpath(csv_file, start=DuplicateEntriesTest.root_path)
+        for csv_file in get_csv_files(TestCase.root_path):
+            short_path = os.path.relpath(csv_file, start=TestCase.root_path)
 
             with self.subTest(msg=f"{short_path}"):
                 data_test = DuplicateEntries()
@@ -63,4 +64,4 @@ class DuplicateEntriesTest(unittest.TestCase):
 
                 short_message = data_test.get_failure_message(max_examples=10)
                 full_message = data_test.get_failure_message()
-                self.__assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
+                self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest
+from data_tests.test_data import DuplicateEntriesTest, TestCase
 
 
 if __name__ == "__main__":
@@ -12,10 +12,11 @@ if __name__ == "__main__":
                                                      "be written to")
     args = parser.parse_args()
 
+    TestCase.root_path = args.root_path
+    TestCase.log_file = args.log_file
+
     test_class = None
     if args.test == "duplicate_entries":
-        DuplicateEntriesTest.root_path = args.root_path
-        DuplicateEntriesTest.log_file = args.log_file
         test_class = DuplicateEntriesTest
     else:
         raise ValueError(f"Unrecognized data test '{args.test}'.")

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest, TruncatedTestResult
+from data_tests.test_data import DuplicateEntriesTest
 
 
 if __name__ == "__main__":
@@ -10,24 +10,18 @@ if __name__ == "__main__":
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
-    parser.add_argument("--max-console-lines", type=int, help="the maximum number of lines of a failure message to "
-                                                              "print to the console")
     args = parser.parse_args()
-
-    if args.log_file is not None:
-        TruncatedTestResult.log_file = args.log_file
-    if args.max_console_lines is not None:
-        TruncatedTestResult.max_console_lines = args.max_console_lines
 
     test_class = None
     if args.test == "duplicate_entries":
         DuplicateEntriesTest.root_path = args.root_path
+        DuplicateEntriesTest.log_file = args.log_file
         test_class = DuplicateEntriesTest
     else:
         raise ValueError(f"Unrecognized data test '{args.test}'.")
 
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(test_class)
-    test_runner = unittest.TextTestRunner(resultclass=TruncatedTestResult)
+    test_runner = unittest.TextTestRunner()
     result = test_runner.run(test_suite)
 
     if result.wasSuccessful():

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,14 +1,23 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest
+from data_tests.test_data import DuplicateEntriesTest, TruncatedTestResult
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("test", type=str, help="the data test to run")
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
+    parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
+                                                     "be written to")
+    parser.add_argument("--max-console-lines", type=int, help="the maximum number of lines of a failure message to "
+                                                              "print to the console")
     args = parser.parse_args()
+
+    if args.log_file is not None:
+        TruncatedTestResult.log_file = args.log_file
+    if args.max_console_lines is not None:
+        TruncatedTestResult.max_console_lines = args.max_console_lines
 
     test_class = None
     if args.test == "duplicate_entries":
@@ -18,7 +27,7 @@ if __name__ == "__main__":
         raise ValueError(f"Unrecognized data test '{args.test}'.")
 
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(test_class)
-    test_runner = unittest.TextTestRunner()
+    test_runner = unittest.TextTestRunner(resultclass=TruncatedTestResult)
     result = test_runner.run(test_suite)
 
     if result.wasSuccessful():


### PR DESCRIPTION
The failures displayed in the console are currently being truncated for easier navigation within the GitHub Actions interface:
```
AssertionError: False is not true : 2505 duplicate rows detected:

        Row 2: ['01-446 Aurora', 'U.S. House', '1', 'Registered Voters', '', '2667']
        Row 8: ['01-446 Aurora', 'U.S. House', '1', 'Registered Voters', '', '2667']
        Row 13: ['01-446 Aurora', 'GOVERNOR', '', 'Registered Voters', '', '2667']
        Row 17: ['01-446 Aurora', 'GOVERNOR', '', 'Registered Voters', '', '2667']
        Row 26: ['01-446 Aurora', 'LIEUTENANT GOVERNOR', '', 'Registered Voters', '', '2667']
        Row 29: ['01-446 Aurora', 'LIEUTENANT GOVERNOR', '', 'Registered Voters', '', '2667']
        Row 37: ['01-446 Aurora', 'State Senate', 'A', 'Registered Voters', '', '2667']
        Row 40: ['01-446 Aurora', 'State Senate', 'A', 'Registered Voters', '', '2667']
        Row 43: ['01-446 Aurora', 'State House', '1', 'Registered Voters', '', '2667']
        Row 46: ['01-446 Aurora', 'State House', '1', 'Registered Voters', '', '2667']
        [Truncated to 10 examples]
```

By adding support for writing the full failure messages to a log file, we can create workflow artifacts that one can download to see all the failures.  Previously, one would have to clone multiple repositories, modify a parameter, and run the tests locally to see all the failures.

See the bottom of [this test run](https://github.com/warwickmm/openelections-data-ak/actions/runs/1167580136) for an example of such an artifact.

An initial attempt using a custom `TestResult` was made in revisions 766ad9e8656c7d567216fa0ff98f6a64869177a7 and 8b9dc2722790892252c08ec779e9e339204d40e1.  However, that approach would not work with (upcoming) tests that concatenate messages from several different sources.  As a result, we arrived at the logging approach proposed here.
