### PR TITLE
Improve detection of duplicate entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ directories named by the corresponding election years.  For example,
 ```
 
 ## Available Tests
-* `duplicate_entries` detects the presence of duplicated entries.
+* `duplicate_entries` detects the presence of duplicate entries.
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -42,7 +42,7 @@ class DuplicateEntries:
             if len(rows) > 1:
                 num_duplicates += len(rows) - 1
 
-        message = f"{num_duplicates} duplicate rows detected:\n"
+        message = f"{num_duplicates} duplicate entries detected:\n"
         count = 0
         for row_hash, row_map in self.__hash_to_rows.items():
             if len(row_map) > 1:

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -8,7 +8,7 @@ class DuplicateEntries:
     def __init__(self, headers: list[str]):
         super().__init__()
         self.__current_row = 0
-        self.__hash_to_rows = {}
+        self.__hash_to_row_map = {}
         self.__passed = True
         self.__headers = headers
 
@@ -45,14 +45,14 @@ class DuplicateEntries:
 
     def get_failure_message(self, max_examples: int = -1) -> str:
         num_duplicates = 0
-        for _, rows in self.__hash_to_rows.items():
+        for _, rows in self.__hash_to_row_map.items():
             if len(rows) > 1:
                 num_duplicates += len(rows) - 1
 
         message = f"{num_duplicates} duplicate entries detected:\n\n" \
-          f"\tHeaders: {self.__headers}:"
+                  f"\tHeaders: {self.__headers}:"
         count = 0
-        for row_hash, row_map in self.__hash_to_rows.items():
+        for row_hash, row_map in self.__hash_to_row_map.items():
             if len(row_map) > 1:
                 for row_number, row in row_map.items():
                     if (max_examples >= 0) and (count >= max_examples):
@@ -68,8 +68,8 @@ class DuplicateEntries:
         self.__current_row += 1
         if not DuplicateEntries.__is_empty(row):
             row_hash = self.__hash_row(row)
-            if row_hash in self.__hash_to_rows:
+            if row_hash in self.__hash_to_row_map:
                 self.__passed = False
-                self.__hash_to_rows[row_hash][self.__current_row] = row
+                self.__hash_to_row_map[row_hash][self.__current_row] = row
             else:
-                self.__hash_to_rows[row_hash] = {self.__current_row: row}
+                self.__hash_to_row_map[row_hash] = {self.__current_row: row}

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -12,16 +12,23 @@ class DuplicateEntries:
         self.__passed = True
         self.__headers = headers
 
+        indices_to_hash = []
+        for i, x in enumerate(self.__headers):
+            lowered_header = x.lower()
+            not_vote_column = "votes" not in lowered_header
+            not_vote_column &= lowered_header not in ["early_voting", "election_day", "mail", "provisional"]
+            if not_vote_column:
+                indices_to_hash.append(i)
+
+        self.__indices_to_hash = indices_to_hash
+
     @property
     def passed(self) -> bool:
         return self.__passed
 
     def __hash_row(self, row: list[str]) -> str:
         if len(row) == len(self.__headers):
-            entries_to_hash = []
-            for i, x in enumerate(self.__headers):
-                if "votes" not in x.lower():
-                    entries_to_hash.append(row[i])
+            entries_to_hash = [row[i] for i in self.__indices_to_hash]
         else:
             entries_to_hash = row
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -16,7 +16,7 @@ class DuplicateEntries:
         for i, x in enumerate(self.__headers):
             lowered_header = x.lower()
             not_vote_column = "votes" not in lowered_header
-            not_vote_column &= lowered_header not in ["absentee", "early_voting", "election_day", "mail", "provisional"]
+            not_vote_column &= lowered_header not in {"absentee", "early_voting", "election_day", "mail", "provisional"}
             if not_vote_column:
                 indices_to_hash.append(i)
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -17,12 +17,16 @@ class DuplicateEntries:
         return self.__passed
 
     def __hash_row(self, row: list[str]) -> str:
-        non_vote_entries = []
-        for i, x in enumerate(self.__headers):
-            if "votes" not in x.lower():
-                non_vote_entries.append(row[i])
+        if len(row) == len(self.__headers):
+            entries_to_hash = []
+            for i, x in enumerate(self.__headers):
+                if "votes" not in x.lower():
+                    entries_to_hash.append(row[i])
+        else:
+            # If this row has an inconsistent number of columns, just hash the entire row.
+            entries_to_hash = row
 
-        hashed_entries = [sha256(x.encode()).hexdigest() for x in non_vote_entries]
+        hashed_entries = [sha256(x.encode()).hexdigest() for x in entries_to_hash]
         return sha256("".join(hashed_entries).encode()).hexdigest()
 
     @staticmethod

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -49,7 +49,8 @@ class DuplicateEntries:
             if len(rows) > 1:
                 num_duplicates += len(rows) - 1
 
-        message = f"{num_duplicates} duplicate entries detected:\n"
+        message = f"{num_duplicates} duplicate entries detected:\n\n" \
+          f"\tHeaders: {self.__headers}:"
         count = 0
         for row_hash, row_map in self.__hash_to_rows.items():
             if len(row_map) > 1:

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -28,7 +28,7 @@ class DuplicateEntries:
 
     def __hash_row(self, row: list[str]) -> str:
         if len(row) == len(self.__headers):
-            entries_to_hash = [row[i] for i in self.__indices_to_hash]
+            entries_to_hash = (row[i] for i in self.__indices_to_hash)
         else:
             entries_to_hash = row
 

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -23,7 +23,6 @@ class DuplicateEntries:
                 if "votes" not in x.lower():
                     entries_to_hash.append(row[i])
         else:
-            # If this row has an inconsistent number of columns, just hash the entire row.
             entries_to_hash = row
 
         hashed_entries = [sha256(x.encode()).hexdigest() for x in entries_to_hash]

--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -16,7 +16,7 @@ class DuplicateEntries:
         for i, x in enumerate(self.__headers):
             lowered_header = x.lower()
             not_vote_column = "votes" not in lowered_header
-            not_vote_column &= lowered_header not in ["early_voting", "election_day", "mail", "provisional"]
+            not_vote_column &= lowered_header not in ["absentee", "early_voting", "election_day", "mail", "provisional"]
             if not_vote_column:
                 indices_to_hash.append(i)
 

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -56,9 +56,12 @@ class DuplicateEntriesTest(TestCase):
             short_path = os.path.relpath(csv_file, start=TestCase.root_path)
 
             with self.subTest(msg=f"{short_path}"):
-                data_test = DuplicateEntries()
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)
+                    headers = next(reader)
+
+                    data_test = DuplicateEntries(headers)
+                    data_test.test(headers)
                     for row in reader:
                         data_test.test(row)
 

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -7,36 +7,42 @@ from data_tests import duplicate_entries
 class DuplicateEntriesTest(unittest.TestCase):
     def test_ragged_with_duplicates(self):
         rows = [
-            ["a", "votes", "c"],
+            ["header 1", "votes", "header 3"],
             ["a", "b", "c"],
             ["a", "b", "c", "d"],
             ["a", "b", "c", "d"]
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])
-        for row in rows[1:]:
+        for row in rows:
             data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
         self.assertRegex(failure_message, "1 duplicate row")
-        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[2]}"))
-        self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[2]}"))
+        self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
 
     def test_ragged_without_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries(["a", "votes", "c"])
-        data_test.test(["a", "b", "c"])
-        data_test.test(["a", "b", "c", "d"])
-        data_test.test(["a", "b", "d", "e"])
-        data_test.test(["", "a", "b", "d", "e"])
-        data_test.test(["a", "b", "d", "e", ""])
-        data_test.test(["", ""])
-        data_test.test(["", ""])
+        rows = [
+            ["header 1", "votes", "header 3"],
+            ["a", "b", "c"],
+            ["a", "b", "c", "d"],
+            ["a", "b", "d", "e"],
+            ["", "a", "b", "d", "e"],
+            ["a", "b", "d", "e", ""],
+            ["", ""],
+            ["", ""]
+        ]
+
+        data_test = duplicate_entries.DuplicateEntries(rows[0])
+        for row in rows:
+            data_test.test(row)
         self.assertTrue(data_test.passed)
 
     def test_with_duplicates(self):
         rows = [
-            ["a", "b", "a_votes_b", "c_votes_d", "e"],
+            ["header 1", "header 2", "a_votes_b", "c_votes_d", "header 5"],
             ["a", "b", "c", "d", "e"],
             ["d", "e", "f", "g", "h"],
             ["a", "b", "cc", "d", "e"],
@@ -45,21 +51,27 @@ class DuplicateEntriesTest(unittest.TestCase):
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])
-        for row in rows[1:]:
+        for row in rows:
             data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
         self.assertRegex(failure_message, "2 duplicate row")
-        self.assertRegex(failure_message, "Row 1.*" + re.escape(f"{rows[1]}"))
-        self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[3]}"))
-        self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[4]}"))
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, "Row 5.*" + re.escape(f"{rows[4]}"))
 
     def test_without_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])
-        data_test.test(["a", "b", "c", "d", "e"])
-        data_test.test(["ab", "", "c", "d", "e"])
-        data_test.test(["a", "b", "c", "de", ""])
-        data_test.test(["", "", "", "", ""])
-        data_test.test(["", "", "", "", ""])
+        rows = [
+            ["header 1", "header 2", "a_votes_b", "c_votes_d", "header 5"],
+            ["a", "b", "c", "d", "e"],
+            ["ab", "", "c", "d", "e"],
+            ["a", "b", "c", "de", ""],
+            ["", "", "", "", ""],
+            ["", "", "", "", ""]
+        ]
+
+        data_test = duplicate_entries.DuplicateEntries(rows[0])
+        for row in rows:
+            data_test.test(row)
         self.assertTrue(data_test.passed)

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -7,8 +7,8 @@ from data_tests import duplicate_entries
 class DuplicateEntriesTest(unittest.TestCase):
     def test_ragged_with_duplicates(self):
         rows = [
-            ["header 1", "votes", "header 3"],
-            ["a", "b", "c"],
+            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional"],
+            ["a", "b", "", "d", "e", "f", "g"],
             ["a", "b", "c", "d"],
             ["a", "b", "c", "d"]
         ]
@@ -27,8 +27,9 @@ class DuplicateEntriesTest(unittest.TestCase):
 
     def test_ragged_without_duplicates(self):
         rows = [
-            ["header 1", "votes", "header 3"],
-            ["a", "b", "c"],
+            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional"],
+            ["a", "b", "c", "d", "e", "f", "g"],
+            ["a", "b", "cc", "d", "e", "f", "g"],
             ["a", "b", "c", "d"],
             ["a", "b", "d", "e"],
             ["", "a", "b", "d", "e"],
@@ -44,12 +45,12 @@ class DuplicateEntriesTest(unittest.TestCase):
 
     def test_with_duplicates(self):
         rows = [
-            ["header 1", "header 2", "a_votes_b", "c_votes_d", "header 5"],
-            ["a", "b", "c", "d", "e"],
-            ["d", "e", "f", "g", "h"],
-            ["a", "b", "cc", "d", "e"],
-            ["a", "b", "c", "dd", "e"],
-            ["d", "e", "f", "g", "i"]
+            ["header 1", "header 2", "a_votes_b", "c_votes_d", "early_voting", "election_day", "mail", "provisional"],
+            ["a", "b", "c", "d", "e", "f", "g", "h"],
+            ["d", "e", "f", "g", "e", "f", "g", "h"],
+            ["a", "b", "cc", "d", "ee", "f", "gg", "h"],
+            ["a", "b", "c", "dd", "e", "ff", "g", "hh"],
+            ["d", "ee", "f", "g", "e", "f", "g", "h"]
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])
@@ -64,15 +65,16 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertNotRegex(failure_message, "Row 3.*")
         self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
         self.assertRegex(failure_message, "Row 5.*" + re.escape(f"{rows[4]}"))
+        self.assertNotRegex(failure_message, "Row 6.*")
 
     def test_without_duplicates(self):
         rows = [
-            ["header 1", "header 2", "a_votes_b", "c_votes_d", "header 5"],
-            ["a", "b", "c", "d", "e"],
-            ["ab", "", "c", "d", "e"],
-            ["a", "b", "c", "de", ""],
-            ["", "", "", "", ""],
-            ["", "", "", "", ""]
+            ["header 1", "header 2", "a_votes_b", "header 5", "early_voting", "election_day", "mail", "provisional"],
+            ["a", "b", "c", "d", "e", "f", "g", "h"],
+            ["ab", "", "c", "d", "e", "f", "g", "h"],
+            ["a", "b", "c", "de", "", "f", "g", "h"],
+            ["", "", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", ""]
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -7,8 +7,8 @@ from data_tests import duplicate_entries
 class DuplicateEntriesTest(unittest.TestCase):
     def test_ragged_with_duplicates(self):
         rows = [
-            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional"],
-            ["a", "b", "", "d", "e", "f", "g"],
+            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional", "absentee"],
+            ["a", "b", "", "d", "e", "f", "g", "h"],
             ["a", "b", "c", "d"],
             ["a", "b", "c", "d"]
         ]
@@ -27,9 +27,9 @@ class DuplicateEntriesTest(unittest.TestCase):
 
     def test_ragged_without_duplicates(self):
         rows = [
-            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional"],
-            ["a", "b", "c", "d", "e", "f", "g"],
-            ["a", "b", "cc", "d", "e", "f", "g"],
+            ["header 1", "votes", "header 3", "early_voting", "election_day", "mail", "provisional", "absentee"],
+            ["a", "b", "c", "d", "e", "f", "g", "h"],
+            ["a", "b", "cc", "d", "e", "f", "g", "h"],
             ["a", "b", "c", "d"],
             ["a", "b", "d", "e"],
             ["", "a", "b", "d", "e"],
@@ -45,12 +45,16 @@ class DuplicateEntriesTest(unittest.TestCase):
 
     def test_with_duplicates(self):
         rows = [
-            ["header 1", "header 2", "a_votes_b", "c_votes_d", "early_voting", "election_day", "mail", "provisional"],
-            ["a", "b", "c", "d", "e", "f", "g", "h"],
-            ["d", "e", "f", "g", "e", "f", "g", "h"],
-            ["a", "b", "cc", "d", "ee", "f", "gg", "h"],
-            ["a", "b", "c", "dd", "e", "ff", "g", "hh"],
-            ["d", "ee", "f", "g", "e", "f", "g", "h"]
+            [
+                "header 1", "header 2", "a_votes_b", "c_votes_d", "early_voting", "election_day", "mail",
+                "provisional", "absentee"
+            ],
+            ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            ["d", "e", "f", "g", "e", "f", "g", "h", "i"],
+            ["a", "b", "cc", "d", "ee", "f", "gg", "h", "i"],
+            ["a", "b", "c", "dd", "e", "ff", "g", "hh", "i"],
+            ["a", "b", "c", "dd", "e", "ff", "g", "h", "ii"],
+            ["d", "ee", "f", "g", "e", "f", "g", "h", "i"]
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])
@@ -59,22 +63,26 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertRegex(failure_message, "2 duplicate entries")
+        self.assertRegex(failure_message, "3 duplicate entries")
         self.assertNotRegex(failure_message, "Row 1.*")
         self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
         self.assertNotRegex(failure_message, "Row 3.*")
         self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
         self.assertRegex(failure_message, "Row 5.*" + re.escape(f"{rows[4]}"))
-        self.assertNotRegex(failure_message, "Row 6.*")
+        self.assertRegex(failure_message, "Row 6.*" + re.escape(f"{rows[5]}"))
+        self.assertNotRegex(failure_message, "Row 7.*")
 
     def test_without_duplicates(self):
         rows = [
-            ["header 1", "header 2", "a_votes_b", "header 5", "early_voting", "election_day", "mail", "provisional"],
-            ["a", "b", "c", "d", "e", "f", "g", "h"],
-            ["ab", "", "c", "d", "e", "f", "g", "h"],
-            ["a", "b", "c", "de", "", "f", "g", "h"],
-            ["", "", "", "", "", "", "", ""],
-            ["", "", "", "", "", "", "", ""]
+            [
+                "header 1", "header 2", "a_votes_b", "header 5", "early_voting", "election_day", "mail",
+                "provisional", "absentee"
+            ],
+            ["a", "b", "c", "d", "e", "f", "g", "h", "i"],
+            ["ab", "", "c", "d", "e", "f", "g", "h", "i"],
+            ["a", "b", "c", "de", "", "f", "g", "h", "i"],
+            ["", "", "", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", "", ""]
         ]
 
         data_test = duplicate_entries.DuplicateEntries(rows[0])

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -4,6 +4,28 @@ from data_tests import duplicate_entries
 
 
 class DuplicateEntriesTest(unittest.TestCase):
+    def test_ragged_with_duplicates(self):
+        data_test = duplicate_entries.DuplicateEntries(["a", "votes", "c"])
+        data_test.test(["a", "b", "c"])
+        data_test.test(["a", "b", "c", "d"])
+        data_test.test(["a", "b", "c", "d"])
+        self.assertFalse(data_test.passed)
+
+        failure_message = data_test.get_failure_message()
+        self.assertIsNotNone(failure_message)
+        self.assertNotEqual("", failure_message)
+
+    def test_ragged_without_duplicates(self):
+        data_test = duplicate_entries.DuplicateEntries(["a", "votes", "c"])
+        data_test.test(["a", "b", "c"])
+        data_test.test(["a", "b", "c", "d"])
+        data_test.test(["a", "b", "d", "e"])
+        data_test.test(["", "a", "b", "d", "e"])
+        data_test.test(["a", "b", "d", "e", ""])
+        data_test.test(["", ""])
+        data_test.test(["", ""])
+        self.assertTrue(data_test.passed)
+
     def test_with_duplicates(self):
         data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])
         data_test.test(["a", "b", "c", "d", "e"])

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 from data_tests import duplicate_entries
@@ -5,15 +6,22 @@ from data_tests import duplicate_entries
 
 class DuplicateEntriesTest(unittest.TestCase):
     def test_ragged_with_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries(["a", "votes", "c"])
-        data_test.test(["a", "b", "c"])
-        data_test.test(["a", "b", "c", "d"])
-        data_test.test(["a", "b", "c", "d"])
+        rows = [
+            ["a", "votes", "c"],
+            ["a", "b", "c"],
+            ["a", "b", "c", "d"],
+            ["a", "b", "c", "d"]
+        ]
+
+        data_test = duplicate_entries.DuplicateEntries(rows[0])
+        for row in rows[1:]:
+            data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertIsNotNone(failure_message)
-        self.assertNotEqual("", failure_message)
+        self.assertRegex(failure_message, "1 duplicate row")
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[2]}"))
+        self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[3]}"))
 
     def test_ragged_without_duplicates(self):
         data_test = duplicate_entries.DuplicateEntries(["a", "votes", "c"])
@@ -27,16 +35,25 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertTrue(data_test.passed)
 
     def test_with_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])
-        data_test.test(["a", "b", "c", "d", "e"])
-        data_test.test(["d", "e", "f", "g", "h"])
-        data_test.test(["a", "b", "cc", "d", "e"])
-        data_test.test(["d", "e", "f", "g", "i"])
+        rows = [
+            ["a", "b", "a_votes_b", "c_votes_d", "e"],
+            ["a", "b", "c", "d", "e"],
+            ["d", "e", "f", "g", "h"],
+            ["a", "b", "cc", "d", "e"],
+            ["a", "b", "c", "dd", "e"],
+            ["d", "e", "f", "g", "i"]
+        ]
+
+        data_test = duplicate_entries.DuplicateEntries(rows[0])
+        for row in rows[1:]:
+            data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertIsNotNone(failure_message)
-        self.assertNotEqual("", failure_message)
+        self.assertRegex(failure_message, "2 duplicate row")
+        self.assertRegex(failure_message, "Row 1.*" + re.escape(f"{rows[1]}"))
+        self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[4]}"))
 
     def test_without_duplicates(self):
         data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -19,7 +19,7 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertRegex(failure_message, "1 duplicate row")
+        self.assertRegex(failure_message, "1 duplicate entries")
         self.assertNotRegex(failure_message, "Row 1.*")
         self.assertNotRegex(failure_message, "Row 2.*")
         self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[2]}"))
@@ -58,7 +58,7 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertRegex(failure_message, "2 duplicate row")
+        self.assertRegex(failure_message, "2 duplicate entries")
         self.assertNotRegex(failure_message, "Row 1.*")
         self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
         self.assertNotRegex(failure_message, "Row 3.*")

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -5,11 +5,11 @@ from data_tests import duplicate_entries
 
 class DuplicateEntriesTest(unittest.TestCase):
     def test_with_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries()
-        data_test.test(["a", "b", "c"])
-        data_test.test(["d", "e", "f"])
-        data_test.test(["a", "b", "c"])
-        data_test.test(["g", "h", "i"])
+        data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])
+        data_test.test(["a", "b", "c", "d", "e"])
+        data_test.test(["d", "e", "f", "g", "h"])
+        data_test.test(["a", "b", "cc", "d", "e"])
+        data_test.test(["d", "e", "f", "g", "i"])
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
@@ -17,11 +17,10 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertNotEqual("", failure_message)
 
     def test_without_duplicates(self):
-        data_test = duplicate_entries.DuplicateEntries()
-        data_test.test(["a", "b", "c"])
-        data_test.test(["ab", "", "c"])
-        data_test.test(["", "a", "b", "c"])
-        data_test.test(["a", "b", "c", ""])
-        data_test.test(["", "", ""])
-        data_test.test(["", "", ""])
+        data_test = duplicate_entries.DuplicateEntries(["a", "b", "a_votes_b", "c_votes_d", "e"])
+        data_test.test(["a", "b", "c", "d", "e"])
+        data_test.test(["ab", "", "c", "d", "e"])
+        data_test.test(["a", "b", "c", "de", ""])
+        data_test.test(["", "", "", "", ""])
+        data_test.test(["", "", "", "", ""])
         self.assertTrue(data_test.passed)

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -20,6 +20,8 @@ class DuplicateEntriesTest(unittest.TestCase):
 
         failure_message = data_test.get_failure_message()
         self.assertRegex(failure_message, "1 duplicate row")
+        self.assertNotRegex(failure_message, "Row 1.*")
+        self.assertNotRegex(failure_message, "Row 2.*")
         self.assertRegex(failure_message, "Row 3.*" + re.escape(f"{rows[2]}"))
         self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
 
@@ -57,7 +59,9 @@ class DuplicateEntriesTest(unittest.TestCase):
 
         failure_message = data_test.get_failure_message()
         self.assertRegex(failure_message, "2 duplicate row")
+        self.assertNotRegex(failure_message, "Row 1.*")
         self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
         self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
         self.assertRegex(failure_message, "Row 5.*" + re.escape(f"{rows[4]}"))
 


### PR DESCRIPTION
This excludes columns that contain vote counts from being considered when looking for duplicate entries.  This allows us to identify rows with the same county/precinct/office/candidate that have different vote values.  Previously, we could only detect entire rows that were duplicated.

For example, CA [currently](https://github.com/openelections/openelections-data-ca/actions/runs/1151366881) does not have any entire rows that are duplicated.  However, with these changes we now find the following duplicate entries in [2014/20140603__ca__primary__kern__precinct.csv](https://github.com/openelections/openelections-data-ca/blob/1770eba163e85d4310fcb5026630084dc668bd02/2014/20140603__ca__primary__kern__precinct.csv):
```
Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
Row 13165: ['Kern', '0040441', 'U.S. House', '23', 'DEM', 'Raul Garcia', '2']
Row 13224: ['Kern', '0040441', 'U.S. House', '23', 'DEM', 'Raul Garcia', '1']
```
and in [2014/20140603__ca__primary__fresno__precinct.csv](https://github.com/openelections/openelections-data-ca/blob/1770eba163e85d4310fcb5026630084dc668bd02/2014/20140603__ca__primary__fresno__precinct.csv):
```
Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
Row 4856: ['Fresno', '0000079', 'U.S. House', '4', '', 'Arthur "Art" Moore', '14']
Row 5032: ['Fresno', '0000079', 'U.S. House', '4', '', 'Arthur "Art" Moore', '65']

```

Another good example is [openelections-data-nj/2020/20201103__nj__general__mercer__precinct.csv](https://github.com/openelections/openelections-data-nj/blob/aa310a834be7b1b693f30c51249f9add07f2e84e/2020/20201103__nj__general__mercer__precinct.csv), where we find inconsistencies like:
```
        Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'mail', 'provisional']:
        Row 24: ['Mercer', 'Ewing', 'President', '', '', 'Registered Voters', '26578', '', '', '']
        Row 46: ['Mercer', 'Ewing', 'President', '', '', 'Registered Voters', '68230', '', '', '']
        Row 25: ['Mercer', 'Ewing', 'President', '', '', 'Ballots Cast', '19034', '18', '17786', '1230']
        Row 47: ['Mercer', 'Ewing', 'President', '', '', 'Ballots Cast', '50130', '40', '47001', '3089']
        Row 26: ['Mercer', 'Ewing', 'President', '', 'DEM', 'Joe Biden', '13718', '8', '12858', '852']
        Row 48: ['Mercer', 'Ewing', 'President', '', 'DEM', 'Joe Biden', '26875', '12', '25225', '1638']
        Row 27: ['Mercer', 'Ewing', 'President', '', 'REP', 'Donald Trump', '4638', '10', '4324', '304']
        Row 49: ['Mercer', 'Ewing', 'President', '', 'REP', 'Donald Trump', '21584', '28', '20310', '1247']
        Row 28: ['Mercer', 'Ewing', 'President', '', 'LIB', 'Jo Jorgensen', '160', '0', '148', '12']
        Row 50: ['Mercer', 'Ewing', 'President', '', 'LIB', 'Jo Jorgensen', '410', '0', '380', '30']
        [Truncated to 10 examples]
```

This also adds improves the unit tests to verify the behavior for these types of cases, and check that the failure messages contain the expected information.
