### PR TITLE
Add test to verify that required values are not missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ directories named by the corresponding election years.  For example,
 ## Available Tests
 * `duplicate_entries` detects the presence of duplicate entries.
 * `vote_breakdown_totals` detects entries where the sum of the broken down votes (e.g., `absentee`, `early_voting`, `election_day`, `mail`, `provisional`) is greater than the total `votes`.
+* `missing_values` verifies that required values are not missing.

--- a/data_tests/missing_values.py
+++ b/data_tests/missing_values.py
@@ -15,17 +15,18 @@ class MissingValue:
     def passed(self) -> bool:
         return len(self.__failures) == 0
 
-    def get_failure_message(self, max_examples: int = 10) -> str:
+    def get_failure_message(self, max_examples: int = -1) -> str:
         message = f"There are {len(self.__failures)} rows that are missing a {self.__required_value}:\n\n" \
                   f"\tHeaders: {self.__headers}:"
 
-        count = 1
-        for key, value in self.__failures.items():
-            message += f"\n\tRow {key}: {value}"
-            count += 1
-            if count > max_examples:
+        count = 0
+        for row_number, row in self.__failures.items():
+            if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
-                break
+                return message
+            else:
+                message += f"\n\tRow {row_number}: {row}"
+                count += 1
 
         return message
 

--- a/data_tests/missing_values.py
+++ b/data_tests/missing_values.py
@@ -1,0 +1,40 @@
+class MissingValue:
+    def __init__(self, required_value: str, headers: list[str]):
+        super().__init__()
+        self.__current_row = 0
+        self.__required_value = required_value
+        self.__headers = headers
+        self.__failures = {}
+
+        if required_value in headers:
+            self.__required_value_index = headers.index(required_value)
+        else:
+            self.__required_value_index = None
+
+    @property
+    def passed(self) -> bool:
+        return len(self.__failures) == 0
+
+    def get_failure_message(self, max_examples: int = 10) -> str:
+        message = f"There are {len(self.__failures)} rows that are missing a {self.__required_value}:\n\n" \
+                  f"\tHeaders: {self.__headers}:"
+
+        count = 1
+        for key, value in self.__failures.items():
+            message += f"\n\tRow {key}: {value}"
+            count += 1
+            if count > max_examples:
+                message += f"\n\t[Truncated to {max_examples} examples]"
+                break
+
+        return message
+
+    def test(self, row: list[str]):
+        self.__current_row += 1
+        if self.__required_value_index is not None:
+            if self.__required_value_index >= len(row):
+                self.__failures[self.__current_row] = row
+            else:
+                value = row[self.__required_value_index]
+                if not value or value.isspace():
+                    self.__failures[self.__current_row] = row

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -7,6 +7,7 @@ from typing import Iterator
 
 from data_tests.duplicate_entries import DuplicateEntries
 from data_tests.inconsistencies import VoteBreakdownTotals
+from data_tests.missing_values import MissingValue
 
 
 def get_csv_files(root_path: str) -> Iterator[str]:
@@ -69,6 +70,44 @@ class DuplicateEntriesTest(TestCase):
                 short_message = data_test.get_failure_message(max_examples=10)
                 full_message = data_test.get_failure_message()
                 self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
+
+
+class MissingValuesTest(TestCase):
+    def test_missing_values(self):
+        for csv_file in get_csv_files(TestCase.root_path):
+            short_path = os.path.relpath(csv_file, start=TestCase.root_path)
+
+            with self.subTest(msg=f"{short_path}"):
+                tests = []
+                with open(csv_file, "r") as csv_data:
+                    reader = csv.reader(csv_data)
+                    headers = next(reader)
+
+                    tests.append(MissingValue("county", headers))
+                    tests.append(MissingValue("precinct", headers))
+                    tests.append(MissingValue("office", headers))
+
+                    for test in tests:
+                        test.test(headers)
+
+                    for row in reader:
+                        for test in tests:
+                            test.test(row)
+
+                passed = True
+                short_message = ""
+                full_message = ""
+                is_first_message = True
+                for test in tests:
+                    if not test.passed:
+                        passed = False
+                        short_message += f"\n\n* {test.get_failure_message(max_examples=10)}"
+                        if not is_first_message:
+                            full_message += "\n\n"
+                        full_message += f"* {test.get_failure_message()}"
+                        is_first_message = False
+
+                self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
 
 
 class VoteBreakdownTotalsTest(TestCase):

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,7 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest, TestCase, VoteBreakdownTotalsTest
+from data_tests.test_data import DuplicateEntriesTest, MissingValuesTest, TestCase, VoteBreakdownTotalsTest
 
 
 if __name__ == "__main__":
@@ -18,6 +18,8 @@ if __name__ == "__main__":
     test_class = None
     if args.test == "duplicate_entries":
         test_class = DuplicateEntriesTest
+    elif args.test == "missing_values":
+        test_class = MissingValuesTest
     elif args.test == "vote_breakdown_totals":
         test_class = VoteBreakdownTotalsTest
     else:

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -91,51 +91,87 @@ class DuplicateEntriesTest(unittest.TestCase):
         self.assertTrue(data_test.passed)
 
 
+# noinspection DuplicatedCode
 class MissingValueTest(unittest.TestCase):
     def test_empty(self):
-        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
-        data_test.test(["1", "2", "3"])
-        data_test.test(["1", "", "3"])
-        data_test.test(["1", "2", "3"])
+        headers = ["a", "b", "c"]
+        rows = [
+            ["1", "2", "3"],
+            ["1", "", "3"],
+            ["1", "2", "3"]
+        ]
+
+        data_test = missing_values.MissingValue("b", headers)
+        for row in rows:
+            data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertIsNotNone(failure_message)
-        self.assertNotEqual("", failure_message)
+        self.assertRegex(failure_message, "1 rows")
+        self.assertNotRegex(failure_message, "Row 1.*")
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
 
     def test_index_out_of_range(self):
-        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
-        data_test.test(["1", "2", "3"])
-        data_test.test(["1"])
+        headers = ["a", "b", "c"]
+        rows = [
+            ["1", "2", "3"],
+            ["1"]
+        ]
+
+        data_test = missing_values.MissingValue("b", headers)
+        for row in rows:
+            data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertIsNotNone(failure_message)
-        self.assertNotEqual("", failure_message)
+        self.assertRegex(failure_message, "1 rows")
+        self.assertNotRegex(failure_message, "Row 1.*")
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
 
     def test_not_applicable(self):
-        data_test = missing_values.MissingValue("d", ["a", "b", "c"])
-        data_test.test(["1", "", "3"])
-        data_test.test(["1", " ", "3"])
+        headers = ["a", "b", "c"]
+        rows = [
+            ["1", "", "3"],
+            ["1", " ", "3"]
+        ]
+
+        data_test = missing_values.MissingValue("d", headers)
+        for row in rows:
+            data_test.test(row)
         self.assertTrue(data_test.passed)
 
     def test_not_missing(self):
-        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
-        data_test.test(["1", "2", "3"])
-        data_test.test(["1", " 2", "3"])
-        data_test.test(["1", "2 ", "3"])
+        headers = ["a", "b", "c"]
+        rows = [
+            ["1", "2", "3"],
+            ["1", " 2", "3"],
+            ["1", "2 ", "3"]
+        ]
+
+        data_test = missing_values.MissingValue("b", headers)
+        for row in rows:
+            data_test.test(row)
         self.assertTrue(data_test.passed)
 
     def test_whitespace(self):
-        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
-        data_test.test(["1", "2", "3"])
-        data_test.test(["1", " \n\t", "3"])
-        data_test.test(["1", "2", "3"])
+        headers = ["a", "b", "c"]
+        rows = [
+            ["1", "2", "3"],
+            ["1", " \n\t", "3"],
+            ["1", "2", "3"]
+        ]
+
+        data_test = missing_values.MissingValue("b", headers)
+        for row in rows:
+            data_test.test(row)
         self.assertFalse(data_test.passed)
 
         failure_message = data_test.get_failure_message()
-        self.assertIsNotNone(failure_message)
-        self.assertNotEqual("", failure_message)
+        self.assertRegex(failure_message, "1 rows")
+        self.assertNotRegex(failure_message, "Row 1.*")
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
 
 
 class VoteBreakdownTotalsTest(unittest.TestCase):

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 
-from data_tests import duplicate_entries, inconsistencies
+from data_tests import duplicate_entries, inconsistencies, missing_values
 
 
 class DuplicateEntriesTest(unittest.TestCase):
@@ -89,6 +89,53 @@ class DuplicateEntriesTest(unittest.TestCase):
         for row in rows:
             data_test.test(row)
         self.assertTrue(data_test.passed)
+
+
+class MissingValueTest(unittest.TestCase):
+    def test_empty(self):
+        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
+        data_test.test(["1", "2", "3"])
+        data_test.test(["1", "", "3"])
+        data_test.test(["1", "2", "3"])
+        self.assertFalse(data_test.passed)
+
+        failure_message = data_test.get_failure_message()
+        self.assertIsNotNone(failure_message)
+        self.assertNotEqual("", failure_message)
+
+    def test_index_out_of_range(self):
+        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
+        data_test.test(["1", "2", "3"])
+        data_test.test(["1"])
+        self.assertFalse(data_test.passed)
+
+        failure_message = data_test.get_failure_message()
+        self.assertIsNotNone(failure_message)
+        self.assertNotEqual("", failure_message)
+
+    def test_not_applicable(self):
+        data_test = missing_values.MissingValue("d", ["a", "b", "c"])
+        data_test.test(["1", "", "3"])
+        data_test.test(["1", " ", "3"])
+        self.assertTrue(data_test.passed)
+
+    def test_not_missing(self):
+        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
+        data_test.test(["1", "2", "3"])
+        data_test.test(["1", " 2", "3"])
+        data_test.test(["1", "2 ", "3"])
+        self.assertTrue(data_test.passed)
+
+    def test_whitespace(self):
+        data_test = missing_values.MissingValue("b", ["a", "b", "c"])
+        data_test.test(["1", "2", "3"])
+        data_test.test(["1", " \n\t", "3"])
+        data_test.test(["1", "2", "3"])
+        self.assertFalse(data_test.passed)
+
+        failure_message = data_test.get_failure_message()
+        self.assertIsNotNone(failure_message)
+        self.assertNotEqual("", failure_message)
 
 
 class VoteBreakdownTotalsTest(unittest.TestCase):


### PR DESCRIPTION
This adds a test to detect rows that are missing a `county`, `precinct`, or `office`.  These fields are expected to be nonempty.
