### PR TITLE
Fix reported row numbers in vote breakdown totals test

### DIFF
--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -121,6 +121,7 @@ class VoteBreakdownTotalsTest(TestCase):
                     headers = next(reader)
 
                     data_test = VoteBreakdownTotals(headers)
+                    data_test.test(headers)
                     for row in reader:
                         data_test.test(row)
 


### PR DESCRIPTION
If we skip the headers, the reported row numbers will be off by one.