### PR TITLE
Add additional validation of test specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,16 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--log-file LOG_FILE] test root_path
+usage: run_tests.py [-h] [--log-file LOG_FILE] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
-  test                 the data test to run
-  root_path            the absolute path to the repository containing files to test
+  {duplicate_entries,missing_values,vote_breakdown_totals}
+                        the data test to run
+  root_path             the absolute path to the repository containing files to test
 
 optional arguments:
-  -h, --help           show this help message and exit
-  --log-file LOG_FILE  the absolute path to a file that the full failure messages will be written to
+  -h, --help            show this help message and exit
+  --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
 ```
 
 The data are expected to be contained in CSV files that reside under

--- a/run_tests.py
+++ b/run_tests.py
@@ -6,7 +6,8 @@ from data_tests.test_data import DuplicateEntriesTest, MissingValuesTest, TestCa
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("test", type=str, help="the data test to run")
+    parser.add_argument("test", choices=["duplicate_entries", "missing_values", "vote_breakdown_totals"], type=str,
+                        help="the data test to run")
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")


### PR DESCRIPTION
This uses the `choices` parameter to make the allowed test names more explicit.