### PR TITLE
Add option to specify maximum number of rows to print

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--log-file LOG_FILE] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
+usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-examples N] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
   {duplicate_entries,missing_values,vote_breakdown_totals}
@@ -15,6 +15,7 @@ positional arguments:
 optional arguments:
   -h, --help            show this help message and exit
   --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
+  --max-examples N      the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.
 ```
 
 The data are expected to be contained in CSV files that reside under

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -18,6 +18,7 @@ def get_csv_files(root_path: str) -> Iterator[str]:
 
 class TestCase(unittest.TestCase):
     log_file = None
+    max_examples = -1
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 
     def __init__(self, *args, **kwargs):
@@ -67,7 +68,7 @@ class DuplicateEntriesTest(TestCase):
                     for row in reader:
                         data_test.test(row)
 
-                short_message = data_test.get_failure_message(max_examples=10)
+                short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
                 full_message = data_test.get_failure_message()
                 self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
 
@@ -101,7 +102,7 @@ class MissingValuesTest(TestCase):
                 for test in tests:
                     if not test.passed:
                         passed = False
-                        short_message += f"\n\n* {test.get_failure_message(max_examples=10)}"
+                        short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
                             full_message += "\n\n"
                         full_message += f"* {test.get_failure_message()}"
@@ -125,6 +126,6 @@ class VoteBreakdownTotalsTest(TestCase):
                     for row in reader:
                         data_test.test(row)
 
-                short_message = data_test.get_failure_message(max_examples=10)
+                short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
                 full_message = data_test.get_failure_message()
                 self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)

--- a/run_tests.py
+++ b/run_tests.py
@@ -11,10 +11,14 @@ if __name__ == "__main__":
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
+    parser.add_argument("--max-examples", type=int, default=10, metavar="N",
+                        help="the maximum number of failing rows to print to the console. If a negative value is "
+                             "provided, all failures will be printed.")
     args = parser.parse_args()
 
     TestCase.root_path = args.root_path
     TestCase.log_file = args.log_file
+    TestCase.max_examples = args.max_examples
 
     test_class = None
     if args.test == "duplicate_entries":


### PR DESCRIPTION
This adds an option to specify the maximum number of failing rows to print to the console.  This makes it easier to discover issues when running the test locally.