### PR TITLE
Exclude aggregate over/under votes from vote breakdown totals test

### DIFF
--- a/data_tests/inconsistencies.py
+++ b/data_tests/inconsistencies.py
@@ -10,6 +10,11 @@ class VoteBreakdownTotals:
         else:
             self.__votes_index = None
 
+        if "candidate" in self.__headers:
+            self.__candidate_index = self.__headers.index("candidate")
+        else:
+            self.__candidate_index = None
+
         components = {"absentee", "early_voting", "election_day", "mail", "provisional"}
         self.__component_indices = [i for i, x in enumerate(self.__headers) if x in components]
 
@@ -37,6 +42,13 @@ class VoteBreakdownTotals:
         self.__current_row += 1
 
         if (len(row) == len(self.__headers)) and self.__votes_index and self.__component_indices:
+            # There are cases where over votes and under votes are reported as a single aggregate.  As such, it's
+            # possible for the votes to be negative.  We will try and avoid these rows.
+            if self.__candidate_index is not None:
+                aggregates = {"over/under", "under/over"}
+                if any(x in row[self.__candidate_index].lower().replace(" ", "") for x in aggregates):
+                    return
+
             try:
                 # We use float instead of int to allow for values like "3.0".
                 votes = float(row[self.__votes_index])

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -294,3 +294,10 @@ class VoteBreakdownTotalsTest(unittest.TestCase):
         data_test = inconsistencies.VoteBreakdownTotals(headers)
         data_test.test(["a", "1", "8", "3", "4"])
         self.assertTrue(data_test.passed)
+
+    def test_skip_aggregate_rows(self):
+        headers = ["candidate", "votes", "mail"]
+        data_test = inconsistencies.VoteBreakdownTotals(headers)
+        data_test.test(["Total Over / Under", "-1", "0"])
+        data_test.test(["Under/ Over Votes", "-1", ""])
+        self.assertTrue(data_test.passed)


### PR DESCRIPTION
There are cases where overvotes and undervotes are reported as an aggregate value.  Since it's possible for this value to be negative, we will try and exclude these rows from the vote breakdown totals test.