### PR TITLE
Add option to group failures by year in console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--log-file LOG_FILE] [--max-examples N] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
+usage: run_tests.py [-h] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
   {duplicate_entries,missing_values,vote_breakdown_totals}
@@ -14,6 +14,7 @@ positional arguments:
 
 optional arguments:
   -h, --help            show this help message and exit
+  --group-failures      group the failures by year in the console output using the GitHub Actions group and endgroup workflow commands
   --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
   --max-examples N      the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.
 ```

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -17,6 +17,23 @@ def get_csv_files(root_path: str) -> Iterator[str]:
             yield file
 
 
+class TestResult(unittest.TextTestResult):
+    def printErrorList(self, flavour, errors):
+        group_map = {}
+        for test, error in errors:
+            group = test.params["group"]
+            if group in group_map:
+                group_map[group].append((test, error))
+            else:
+                group_map[group] = [(test, error)]
+
+        for group in sorted(group_map.keys()):
+            self.stream.write(f"::group::{group}\n")
+            # noinspection PyTypeChecker
+            super().printErrorList(flavour, group_map[group])
+            self.stream.write("::endgroup::\n")
+
+
 class TestCase(unittest.TestCase):
     log_file = None
     max_examples = -1

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -18,20 +18,26 @@ def get_csv_files(root_path: str) -> Iterator[str]:
 
 
 class TestResult(unittest.TextTestResult):
+    # noinspection PyTypeChecker
     def printErrorList(self, flavour, errors):
         group_map = {}
+        ungrouped_errors = []
         for test, error in errors:
-            group = test.params["group"]
-            if group in group_map:
-                group_map[group].append((test, error))
+            if "group" in test.params:
+                group = test.params["group"]
+                if group in group_map:
+                    group_map[group].append((test, error))
+                else:
+                    group_map[group] = [(test, error)]
             else:
-                group_map[group] = [(test, error)]
+                ungrouped_errors.append((test, error))
 
         for group in sorted(group_map.keys()):
             self.stream.write(f"::group::{group}\n")
-            # noinspection PyTypeChecker
             super().printErrorList(flavour, group_map[group])
             self.stream.write("::endgroup::\n")
+
+        super().printErrorList(flavour, ungrouped_errors)
 
 
 class TestCase(unittest.TestCase):

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -2,6 +2,7 @@ import csv
 import glob
 import logging
 import os
+import pathlib
 import unittest
 from typing import Iterator
 
@@ -57,8 +58,9 @@ class DuplicateEntriesTest(TestCase):
     def test_duplicate_entries(self):
         for csv_file in get_csv_files(TestCase.root_path):
             short_path = os.path.relpath(csv_file, start=TestCase.root_path)
+            year = pathlib.Path(short_path).parts[0]
 
-            with self.subTest(msg=f"{short_path}"):
+            with self.subTest(msg=f"{short_path}", group=year):
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)
                     headers = next(reader)
@@ -77,8 +79,9 @@ class MissingValuesTest(TestCase):
     def test_missing_values(self):
         for csv_file in get_csv_files(TestCase.root_path):
             short_path = os.path.relpath(csv_file, start=TestCase.root_path)
+            year = pathlib.Path(short_path).parts[0]
 
-            with self.subTest(msg=f"{short_path}"):
+            with self.subTest(msg=f"{short_path}", group=year):
                 tests = []
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)
@@ -115,8 +118,9 @@ class VoteBreakdownTotalsTest(TestCase):
     def test_vote_method_totals(self):
         for csv_file in get_csv_files(TestCase.root_path):
             short_path = os.path.relpath(csv_file, start=TestCase.root_path)
+            year = pathlib.Path(short_path).parts[0]
 
-            with self.subTest(msg=f"{short_path}"):
+            with self.subTest(msg=f"{short_path}", group=year):
                 with open(csv_file, "r") as csv_data:
                     reader = csv.reader(csv_data)
                     headers = next(reader)

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,14 +1,16 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest, MissingValuesTest, TestCase, VoteBreakdownTotalsTest
-
+from data_tests.test_data import DuplicateEntriesTest, MissingValuesTest, TestCase, VoteBreakdownTotalsTest, TestResult
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("test", choices=["duplicate_entries", "missing_values", "vote_breakdown_totals"], type=str,
                         help="the data test to run")
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
+    parser.add_argument("--group-failures", action="store_true",
+                        help="group the failures by year in the console output using the GitHub Actions group and "
+                             "endgroup workflow commands")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
     parser.add_argument("--max-examples", type=int, default=10, metavar="N",
@@ -30,8 +32,9 @@ if __name__ == "__main__":
     else:
         raise ValueError(f"Unrecognized data test '{args.test}'.")
 
+    result_class = TestResult if args.group_failures else None
+    test_runner = unittest.TextTestRunner(resultclass=result_class)
     test_suite = unittest.defaultTestLoader.loadTestsFromTestCase(test_class)
-    test_runner = unittest.TextTestRunner()
     result = test_runner.run(test_suite)
 
     if result.wasSuccessful():


### PR DESCRIPTION
This adds an option to group the failures by year in the console output using the GitHub Actions  `group` and `endgroup` [workflow commands](https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#grouping-log-lines). Previously, one would have to navigate possibly tens of thousands of lines of output.  Now, the results are grouped by year and folded by default:

![image](https://user-images.githubusercontent.com/17345532/137664107-eb87a409-ca23-4dea-abf7-472e2b2c1bf1.png)

This fixes #15.