### PR TITLE
Check vote breakdown totals for equality when possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,5 @@ directories named by the corresponding election years.  For example,
 
 ## Available Tests
 * `duplicate_entries` detects the presence of duplicate entries.
-* `vote_breakdown_totals` detects entries where the sum of the broken down votes (e.g., `absentee`, `early_voting`, `election_day`, `mail`, `provisional`) is greater than the total `votes`.
+* `vote_breakdown_totals` detects entries where the sum of the broken down votes (e.g., `absentee`, `early_voting`, `election_day`, `mail`, `provisional`) is greater than the total `votes`.  If the column headers match some known schemas, then the values are compared for equality.
 * `missing_values` verifies that required values are not missing.

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -268,6 +268,28 @@ class RunTestsTest(unittest.TestCase):
 
 
 class VoteBreakdownTotalsTest(unittest.TestCase):
+    def test_check_equality(self):
+        headers = ["county", "precinct", "office", "district", "party", "candidate", "election_day", "votes",
+                   "early_voting", "mail", "provisional"]
+        rows = [
+            ["a", "b", "c", "d", "e", "f", "", "12", "3", "4", "5"],
+            ["a", "b", "c", "d", "e", "f", "2", "15", "3", "4", "5"],
+            ["a", "b", "c", "d", "e", "f", "1", "13", "3", "4", "5"],
+            ["a", "b", "c", "d", "e", "f", "4", "15.0", "", "7", "5"],
+        ]
+
+        data_test = inconsistencies.VoteBreakdownTotals(headers)
+        for row in rows:
+            data_test.test(row)
+        self.assertFalse(data_test.passed)
+
+        failure_message = data_test.get_failure_message()
+        self.assertRegex(failure_message, "2 rows")
+        self.assertNotRegex(failure_message, "Row 1.*")
+        self.assertRegex(failure_message, "Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
+        self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
+
     def test_consistent(self):
         headers = ["header", "provisional", "mail", "votes", "early_voting", "election_day", "absentee"]
         rows = [

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -268,7 +268,7 @@ class RunTestsTest(unittest.TestCase):
 
 
 class VoteBreakdownTotalsTest(unittest.TestCase):
-    def test_check_equality(self):
+    def test_equality(self):
         headers = ["county", "precinct", "office", "district", "party", "candidate", "election_day", "votes",
                    "early_voting", "mail", "provisional"]
         rows = [
@@ -290,7 +290,7 @@ class VoteBreakdownTotalsTest(unittest.TestCase):
         self.assertNotRegex(failure_message, "Row 3.*")
         self.assertRegex(failure_message, "Row 4.*" + re.escape(f"{rows[3]}"))
 
-    def test_consistent(self):
+    def test_inequality_consistent(self):
         headers = ["header", "provisional", "mail", "votes", "early_voting", "election_day", "absentee"]
         rows = [
             ["a", "1", "2", "15", "3", "4", "5"],
@@ -309,7 +309,7 @@ class VoteBreakdownTotalsTest(unittest.TestCase):
             data_test.test(row)
         self.assertTrue(data_test.passed)
 
-    def test_inconsistent(self):
+    def test_inequality_inconsistent(self):
         headers = ["header", "provisional", "mail", "votes", "early_voting", "election_day", "absentee"]
         rows = [
             ["a", "1", "3", "15", "3", "4", "5"],


### PR DESCRIPTION
Previously, we only verified that the sum of the vote breakdowns is not greater than the total votes.  However, if the set of column headers matches some known schemas, then we can check the vote breakdown totals for equality.  To start, we will check for equality when the set of column headers matches the set
```
{"county", "precinct", "office", "district", "party", "candidate", "votes", "early_voting", "election_day", "provisional", "mail"}
```