### PR TITLE
Incorporate file format tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {duplicate_entries,missing_values,vote_breakdown_totals} root_path
+usage: run_tests.py [-h] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {file_format,duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
-  {duplicate_entries,missing_values,vote_breakdown_totals}
-                        the data test to run
+  {file_format,duplicate_entries,missing_values,vote_breakdown_totals}
+                        the test to run
   root_path             the absolute path to the repository containing files to test
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --group-failures      group the failures by year in the console output using the GitHub Actions group and endgroup workflow commands
   --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
@@ -36,6 +36,7 @@ directories named by the corresponding election years.  For example,
 ```
 
 ## Available Tests
+* `file_format` verifies the format of the data files.
 * `duplicate_entries` detects the presence of duplicate entries.
 * `vote_breakdown_totals` detects entries where the sum of the broken down votes (e.g., `absentee`, `early_voting`, `election_day`, `mail`, `provisional`) is greater than the total `votes`.  If the column headers match some known schemas, then the values are compared for equality.
 * `missing_values` verifies that required values are not missing.

--- a/data_tests/format_tests.py
+++ b/data_tests/format_tests.py
@@ -1,0 +1,331 @@
+import re
+from abc import ABC, abstractmethod
+
+
+class FormatTest(ABC):
+    @property
+    @abstractmethod
+    def passed(self) -> bool:
+        pass
+
+    @abstractmethod
+    def get_failure_message(self, max_examples: int) -> str:
+        pass
+
+    @abstractmethod
+    def test(self, value):
+        pass
+
+
+# noinspection PyAbstractClass
+class RowTest(FormatTest):
+    def __init__(self):
+        super().__init__()
+        self.__current_row = 0
+
+    @property
+    def current_row(self) -> int:
+        return self.__current_row
+
+    def test(self, value):
+        self.__current_row += 1
+        self._test_row(value)
+
+    @abstractmethod
+    def _test_row(self, row: list[str]):
+        pass
+
+
+class ValueTest(RowTest):
+    def __init__(self):
+        super().__init__()
+        self.__failures = {}
+
+    @property
+    @abstractmethod
+    def description(self) -> str:
+        pass
+
+    @property
+    def passed(self):
+        return len(self.__failures) == 0
+
+    def get_failure_message(self, max_examples=-1):
+        message = f"There are {len(self.__failures)} rows that have entries with {self.description}:\n"
+        count = 0
+        for key, value in self.__failures.items():
+            if (max_examples >= 0) and (count >= max_examples):
+                message += f"\n\t[Truncated to {max_examples} examples]"
+                return message
+            else:
+                message += f"\n\tRow {key}: {value}"
+                count += 1
+
+        return message
+
+    @abstractmethod
+    def is_bad_value(self, value) -> bool:
+        pass
+
+    def _test_row(self, row: list[str]):
+        for entry in row:
+            if self.is_bad_value(entry):
+                self.__failures[self.current_row] = row
+                break
+
+
+class EmptyHeaders(FormatTest):
+    def __init__(self):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} has empty entries."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = "" not in headers
+
+
+class LowercaseHeaders(FormatTest):
+    def __init__(self):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} should only contain lowercase characters."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = headers == [x.lower() for x in headers]
+
+
+class MissingHeaders(FormatTest):
+    def __init__(self, required_headers: set[str]):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+        self.__required_headers = required_headers
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} is missing entries: {self.__required_headers.difference(self.__headers)}."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = self.__required_headers.issubset(headers)
+
+
+class UnknownHeaders(FormatTest):
+    def __init__(self):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} has unknown entries."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = "unknown" not in [x.strip().lower() for x in headers]
+
+
+class WhitespaceInHeaders(FormatTest):
+    regex = re.compile(r"\s")
+
+    def __init__(self):
+        super().__init__()
+        self.__headers = []
+        self.__passed = True
+
+    @property
+    def passed(self):
+        return self.__passed
+
+    def get_failure_message(self, max_examples=0):
+        return f"Header {self.__headers} contains whitespace characters."
+
+    def test(self, headers: list[str]):
+        self.__headers = headers
+        self.__passed = not any(bool(WhitespaceInHeaders.regex.search(x)) for x in self.__headers)
+
+
+class ConsecutiveSpaces(ValueTest):
+    regex = re.compile(r"\s{2,}")
+
+    @property
+    def description(self):
+        return "consecutive whitespace characters"
+
+    def is_bad_value(self, value):
+        return bool(ConsecutiveSpaces.regex.search(value))
+
+
+class EmptyRows(RowTest):
+    regex = re.compile(r"\S")
+
+    def __init__(self):
+        super().__init__()
+        self.__empty_row_count = 0
+
+    @property
+    def passed(self):
+        return self.__empty_row_count == 0
+
+    def get_failure_message(self, max_examples=0):
+        return f"Has {self.__empty_row_count} empty rows."
+
+    def _test_row(self, row: list[str]):
+        has_content = False
+        for entry in row:
+            has_content |= bool(EmptyRows.regex.search(entry))
+
+        if not has_content:
+            self.__empty_row_count += 1
+
+
+class InconsistentNumberOfColumns(RowTest):
+    def __init__(self, headers):
+        super().__init__()
+        self.__failures = {}
+        self.__headers = headers
+
+    @property
+    def passed(self):
+        return len(self.__failures) == 0
+
+    def get_failure_message(self, max_examples=-1):
+        message = f"Header has {len(self.__headers)} entries, but there are {len(self.__failures)} " \
+                  f"rows with an inconsistent number of columns:\n\n" \
+                  f"\tHeaders ({len(self.__headers)} entries): {self.__headers}:"
+
+        count = 0
+        for key, value in self.__failures.items():
+            if (max_examples >= 0) and (count >= max_examples):
+                message += f"\n\t[Truncated to {max_examples} examples]"
+                return message
+            else:
+                message += f"\n\tRow {key} ({len(value)} entries): {value}"
+                count += 1
+
+        return message
+
+    def _test_row(self, row: list[str]):
+        if len(row) != len(self.__headers):
+            self.__failures[self.current_row] = row
+
+
+class NonIntegerVotes(RowTest):
+    def __init__(self, headers: list[str]):
+        super().__init__()
+        self.__failures = {}
+        self.__headers = headers
+
+        columns_to_check = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
+        lowercase_headers = [x.strip().lower() for x in headers]
+        indices_to_check = []
+        for index, header in enumerate(lowercase_headers):
+            if header in columns_to_check:
+                indices_to_check.append(index)
+        self.__indices_to_check = indices_to_check
+
+        if "candidate" in lowercase_headers:
+            self.__candidate_index = lowercase_headers.index("candidate")
+        else:
+            self.__candidate_index = None
+
+    @property
+    def passed(self):
+        return len(self.__failures) == 0
+
+    def get_failure_message(self, max_examples=-1):
+        message = f"There are {len(self.__failures)} rows with votes that aren't integers:\n\n" \
+                  f"\tHeaders: {self.__headers}:"
+
+        count = 0
+        for key, value in self.__failures.items():
+            if (max_examples >= 0) and (count >= max_examples):
+                message += f"\n\t[Truncated to {max_examples} examples]"
+                return message
+            else:
+                message += f"\n\tRow {key}: {value}"
+                count += 1
+
+        return message
+
+    def _test_row(self, row: list[str]):
+        if len(row) == len(self.__headers):
+            for value in (row[i] for i in self.__indices_to_check):
+                # There are some rare cases where the value represents a turnout percentage.  We will try and avoid
+                # these rows.
+                percentages = {"%", "pct", "percent"}
+                if self.__candidate_index is not None \
+                        and any(x in row[self.__candidate_index].lower() for x in percentages):
+                    continue
+
+                # If the value isn't numeric, skip the test.  This can be due to the row having an inconsistent
+                # number of columns (hence the index of the "votes" column is invalid), or the value has been
+                # redacted and is represented by a non-numeric character.
+                try:
+                    float_value = float(value)
+                except ValueError:
+                    continue
+
+                # This allows for "3" and "3.0", but not "3.1".
+                if not float(float_value).is_integer():
+                    self.__failures[self.current_row] = row
+
+
+class LeadingAndTrailingSpaces(ValueTest):
+    @property
+    def description(self):
+        return "leading or trailing whitespace characters"
+
+    def is_bad_value(self, value):
+        return value != value.strip()
+
+
+class NonAlphanumericEntries(ValueTest):
+    regex = re.compile(r"\w")
+
+    @property
+    def description(self):
+        return "only non-alphanumeric characters"
+
+    def is_bad_value(self, value):
+        return value != "" and not bool(NonAlphanumericEntries.regex.search(value))
+
+
+class PrematureLineBreaks(ValueTest):
+    @property
+    def description(self):
+        return "newline characters"
+
+    def is_bad_value(self, value):
+        return "\n" in value
+
+
+class TabCharacters(ValueTest):
+    @property
+    def description(self):
+        return "tab characters"
+
+    def is_bad_value(self, value):
+        return "\t" in value

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,12 +1,13 @@
 import argparse
 import unittest
 
-from data_tests.test_data import DuplicateEntriesTest, MissingValuesTest, TestCase, VoteBreakdownTotalsTest, TestResult
+from data_tests.test_data import (DuplicateEntriesTest, FileFormatTests, MissingValuesTest, TestCase, TestResult,
+                                  VoteBreakdownTotalsTest)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("test", choices=["duplicate_entries", "missing_values", "vote_breakdown_totals"], type=str,
-                        help="the data test to run")
+    parser.add_argument("test", choices=["file_format", "duplicate_entries", "missing_values",
+                                         "vote_breakdown_totals"], type=str, help="the data test to run")
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
     parser.add_argument("--group-failures", action="store_true",
                         help="group the failures by year in the console output using the GitHub Actions group and "
@@ -23,7 +24,9 @@ if __name__ == "__main__":
     TestCase.max_examples = args.max_examples
 
     test_class = None
-    if args.test == "duplicate_entries":
+    if args.test == "file_format":
+        test_class = FileFormatTests
+    elif args.test == "duplicate_entries":
         test_class = DuplicateEntriesTest
     elif args.test == "missing_values":
         test_class = MissingValuesTest

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -1,0 +1,391 @@
+import csv
+import os
+import re
+import subprocess
+import tempfile
+import unittest
+
+from data_tests import format_tests
+
+
+class ConsecutiveSpacesTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.ConsecutiveSpaces()
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        format_test = format_tests.ConsecutiveSpaces()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["a", "b  c", "d"],
+            ["a", "  b", "d"],
+            ["a", "b", "c"],
+            ["a", "b  ", "d"],
+            ["a", "b \t", "d"],
+            ["a", "b \n", "d"],
+        ]
+
+        format_test = format_tests.ConsecutiveSpaces()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "5 rows.*consecutive whitespace")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertRegex(failure_message, f"Row 2.*" + re.escape(f"{rows[1]}"))
+        self.assertNotRegex(failure_message, "Row 3.*")
+        self.assertRegex(failure_message, f"Row 4.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, f"Row 5.*" + re.escape(f"{rows[4]}"))
+        self.assertRegex(failure_message, f"Row 6.*" + re.escape(f"{rows[5]}"))
+
+
+class EmptyHeadersTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.EmptyHeaders()
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.EmptyHeaders()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        header = ["a", "", "c"]
+        format_test = format_tests.EmptyHeaders()
+        format_test.test(header)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, re.escape(f"{header}") + ".*empty entries")
+
+
+class EmptyRowsTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.EmptyRows()
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        format_test = format_tests.EmptyRows()
+        format_test.test(["a", "b", ""])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["", "", ""],
+            ["a", "b", ""],
+            [" ", "\t", "\n"]
+        ]
+
+        format_test = format_tests.EmptyRows()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "2 empty rows")
+
+
+class InconsistentNumberOfColumnsTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.InconsistentNumberOfColumns(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        headers = ["a", "b", "c"]
+
+        format_test = format_tests.InconsistentNumberOfColumns(headers)
+        format_test.test(["d", "e", ""])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["d", "e"],
+            ["d", "e", ""],
+            ["d", "e", "f", "g"],
+            ["d", "e", ""],
+        ]
+
+        format_test = format_tests.InconsistentNumberOfColumns(headers)
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "2 rows.*inconsistent number of columns")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+        self.assertRegex(failure_message, f"Row 3.*" + re.escape(f"{rows[2]}"))
+        self.assertNotRegex(failure_message, "Row 4.*")
+
+
+class LeadingAndTrailingSpacesTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.LeadingAndTrailingSpaces()
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        format_test = format_tests.LeadingAndTrailingSpaces()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["a", " b", "c"],
+            ["a", "b", "c"],
+            ["a", "b ", "c"],
+            ["a", "\tb", "c"],
+            ["a", "b\n", "c"],
+        ]
+
+        format_test = format_tests.LeadingAndTrailingSpaces()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, "4 rows.*leading or trailing whitespace")
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+        self.assertRegex(failure_message, f"Row 3.*" + re.escape(f"{rows[2]}"))
+        self.assertRegex(failure_message, f"Row 4.*" + re.escape(f"{rows[3]}"))
+        self.assertRegex(failure_message, f"Row 5.*" + re.escape(f"{rows[4]}"))
+
+
+class LowercaseHeadersTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.LowercaseHeaders()
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.LowercaseHeaders()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        header = ["a", "B", "c"]
+        format_test = format_tests.LowercaseHeaders()
+        format_test.test(header)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, re.escape(f"{header}") + ".*lowercase")
+
+
+class NonIntegerVotesTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.NonIntegerVotes(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.NonIntegerVotes(["a", "b", "c"])
+        format_test.test(["a", "1.2", "c"])
+        self.assertTrue(format_test.passed)
+
+        format_test = format_tests.NonIntegerVotes(["a", "Percentage", "c"])
+        format_test.test(["a", "1.2", "c"])
+        self.assertTrue(format_test.passed)
+
+        good_values = ["*", "2", "2.0", "-2", "-2.0"]
+        format_test = format_tests.NonIntegerVotes(["a", "votes", "c"])
+        for value in good_values:
+            format_test.test(["a", value, "c"])
+            self.assertTrue(format_test.passed)
+
+        bad_values = ["1.2", "-1.2", "0.01"]
+        vote_columns = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
+        for column in vote_columns:
+            for value in bad_values:
+                bad_row = ["a", 1, value, "c"]
+                format_test = format_tests.NonIntegerVotes(["a", "votes ", column, "c"])
+                format_test.test(["a", 1, 2, "c"])
+                format_test.test(bad_row)
+                self.assertFalse(format_test.passed)
+
+                failure_message = format_test.get_failure_message()
+                self.assertNotRegex(failure_message, "Row 1.*")
+                self.assertRegex(failure_message, f"Row 2.*" + re.escape(f"{bad_row}"))
+
+
+class PrematureLineBreaks(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.PrematureLineBreaks()
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        format_test = format_tests.PrematureLineBreaks()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["a", "b\nc", "d"],
+            ["a", "b", "c"],
+        ]
+
+        format_test = format_tests.PrematureLineBreaks()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+
+
+class TabCharacters(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.TabCharacters()
+        self.assertTrue(format_test.passed)
+
+    def test_row(self):
+        format_test = format_tests.TabCharacters()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        rows = [
+            ["a", "b\tc", "d"],
+            ["a", "b", "c"],
+        ]
+
+        format_test = format_tests.TabCharacters()
+        for row in rows:
+            format_test.test(row)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Row 1.*" + re.escape(f"{rows[0]}"))
+        self.assertNotRegex(failure_message, "Row 2.*")
+
+
+class UnknownHeadersTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.UnknownHeaders()
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.UnknownHeaders()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        bad_header = ["a", "UnkNowN", "c"]
+        format_test = format_tests.UnknownHeaders()
+        format_test.test(bad_header)
+        self.assertFalse(format_test.passed)
+
+        failure_message = format_test.get_failure_message()
+        self.assertRegex(failure_message, f"Header.*" + re.escape(f"{bad_header}") + ".*unknown entries")
+
+
+class WhitespaceInHeadersTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.WhitespaceInHeaders()
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.WhitespaceInHeaders()
+        format_test.test(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+        bad_headers = [
+            ["a", "b ", "c"],
+            ["a", " b", "c"],
+            ["a", "b\n", "c"],
+            ["a", "\nb", "c"],
+            ["a", "b\t", "c"],
+            ["a", "\tb", "c"],
+            ["a", "b c", "d"],
+            ["a", "b\nc", "d"],
+            ["a", "b\tc", "d"],
+        ]
+        for bad_header in bad_headers:
+            format_test = format_tests.WhitespaceInHeaders()
+            format_test.test(bad_header)
+            self.assertFalse(format_test.passed)
+
+            failure_message = format_test.get_failure_message()
+            self.assertRegex(failure_message, f"Header.*" + re.escape(f"{bad_header}") + ".*whitespace")
+
+
+class RunTestsTest(unittest.TestCase):
+    bad_data_dir = None
+    bad_rows = [
+        ["County", "unknown", "absentee votes", "votes", ""],  # Lowercase, unknown, whitespace, and empty headers
+        ["", "", "", "", ""],  # Empty rows
+        ["a", "b  c", "1", "2", "3"],  # Consecutive whitespace
+        ["a", "b", "c", "1", "2", "3"],  # Inconsistent number of columns
+        ["a", "b", "1", "2.5", "3"],  # Non-integer votes
+        [" a", "b", "1", "2", "3"],  # Leading whitespace
+        ["a ", "b", "1", "2", "3"],  # Trailing whitespace
+        ["a", "b", "1\n2", "2", "3"],  # Premature linebreak
+        ["a", "b", "1\t2", "2", "3"],  # Tab
+        ["a", "b", "1", "2", "3"],  # No errors
+    ]
+    good_data_dir = None
+    good_rows = [
+        ["county", "precinct", "absentee", "votes"],
+        ["a", "b", "1", "2"],
+        ["c", "d", "2", "3"],
+    ]
+    root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    year = "2020"
+
+    @staticmethod
+    def create_data(root_path, year, rows):
+        year_dir = os.path.join(root_path, year)
+        os.mkdir(year_dir)
+        _, csv_file_path = tempfile.mkstemp(suffix=".csv", dir=year_dir, text=True)
+        with open(csv_file_path, "w") as csv_file:
+            writer = csv.writer(csv_file)
+            writer.writerows(rows)
+
+    @classmethod
+    def setUpClass(cls):
+        cls.bad_data_dir = tempfile.TemporaryDirectory()
+        RunTestsTest.create_data(cls.bad_data_dir.name, cls.year, cls.bad_rows)
+
+        cls.good_data_dir = tempfile.TemporaryDirectory()
+        RunTestsTest.create_data(cls.good_data_dir.name, cls.year, cls.good_rows)
+
+    def setUp(self):
+        self.log_file = tempfile.NamedTemporaryFile(dir=self.bad_data_dir.name)
+
+    def run_test(self, root_path, *args):
+        command = ["python", os.path.join(RunTestsTest.root_path, "run_tests.py"), "file_format",
+                   f"--log-file={self.log_file.name}"]
+        command.extend(args)
+        command.append(root_path)
+        completed_process = subprocess.run(command, capture_output=True)
+        return completed_process
+
+    def test_group_failures(self):
+        completed_process = self.run_test(self.bad_data_dir.name)
+        ungrouped_output = completed_process.stderr.decode()
+        self.assertNotRegex(ungrouped_output, "::group::")
+        self.assertNotRegex(ungrouped_output, "::endgroup::")
+
+        ungrouped_lines = ungrouped_output.splitlines()
+        bad_row_indices = [i for i, row in enumerate(ungrouped_lines) if re.search("----------", row)]
+        expected_group_body = "\n".join(ungrouped_lines[:bad_row_indices[-1]])
+
+        completed_process = self.run_test(self.bad_data_dir.name, "--group-failures")
+        grouped_output = completed_process.stderr.decode()
+        self.assertRegex(grouped_output, rf"::group::{self.year}\s*{re.escape(expected_group_body)}\s*::endgroup::")
+
+    def test_failure(self):
+        self.assertEqual(1, self.run_test(self.bad_data_dir.name).returncode)
+
+        with open(self.log_file.name, "r") as log_file:
+            log_file_contents = "\n".join(log_file.readlines())
+
+        self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*lowercase")
+        self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*unknown")
+        self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*whitespace")
+        self.assertRegex(log_file_contents, "Header.*" + re.escape(f"{self.bad_rows[0]}") + ".*empty")
+        self.assertRegex(log_file_contents, "1 empty rows")
+        self.assertRegex(log_file_contents, "1 rows.*consecutive whitespace")
+        self.assertRegex(log_file_contents, "1 rows.*inconsistent number of columns")
+        self.assertRegex(log_file_contents, "1 rows.*integers")
+        self.assertRegex(log_file_contents, "2 rows.*leading or trailing whitespace")
+        self.assertRegex(log_file_contents, "1 rows.*newline characters")
+        self.assertRegex(log_file_contents, "1 rows.*tab characters")
+        self.assertNotRegex(log_file_contents, re.escape(f"{self.bad_rows[-1]}"))
+
+    def test_success(self):
+        self.assertEqual(0, self.run_test(self.good_data_dir.name).returncode)


### PR DESCRIPTION
This incorporates the file format tests from the [openelections-format-tests](https://github.com/openelections/openelections-format-tests) repository.

The structure of the data tests and file format tests ended up becoming more similar then initially envisioned.  Combining these will allow us to unify how issues are raised, and open up the possibility of developing more user friendly ways of reporting errors in the data.

The file format tests repository will be marked as deprecated and [archived](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories).