### PR TITLE
Add test to verify that votes are nonnegative

### DIFF
--- a/data_tests/format_tests.py
+++ b/data_tests/format_tests.py
@@ -295,6 +295,29 @@ class VotesTest(RowTest):
                     self.__failures[self.current_row] = row
 
 
+class NegativeVotes(VotesTest):
+    def __init__(self, headers: list[str]):
+        super().__init__(headers)
+
+    @property
+    def _failure_description(self) -> str:
+        return "are negative"
+
+    def _is_bad_value(self, candidate: str, value: float) -> bool:
+        # There are cases where over votes and under votes are reported as a single aggregate.  As such, it's
+        # possible for the votes to be negative.  We will try and avoid these rows.
+        if candidate is not None:
+            aggregates = {"over/under", "under/over"}
+            if any(x in candidate.lower().replace(" ", "") for x in aggregates):
+                return False
+
+            # Under votes are sometimes reported as negative values.  We will try and avoid these rows.
+            if candidate.lower() == "under votes":
+                return False
+
+        return value < 0
+
+
 class NonIntegerVotes(VotesTest):
     def __init__(self, headers: list[str]):
         super().__init__(headers)

--- a/data_tests/format_tests.py
+++ b/data_tests/format_tests.py
@@ -232,7 +232,7 @@ class InconsistentNumberOfColumns(RowTest):
             self.__failures[self.current_row] = row
 
 
-class NonIntegerVotes(RowTest):
+class VotesTest(RowTest):
     def __init__(self, headers: list[str]):
         super().__init__()
         self.__failures = {}
@@ -252,11 +252,20 @@ class NonIntegerVotes(RowTest):
             self.__candidate_index = None
 
     @property
-    def passed(self):
+    @abstractmethod
+    def _failure_description(self) -> str:
+        pass
+
+    @property
+    def passed(self) -> bool:
         return len(self.__failures) == 0
 
-    def get_failure_message(self, max_examples=-1):
-        message = f"There are {len(self.__failures)} rows with votes that aren't integers:\n\n" \
+    @abstractmethod
+    def _is_bad_value(self, candidate: str, value: float) -> bool:
+        pass
+
+    def get_failure_message(self, max_examples=-1) -> str:
+        message = f"There are {len(self.__failures)} rows with votes that {self._failure_description}:\n\n" \
                   f"\tHeaders: {self.__headers}:"
 
         count = 0
@@ -273,13 +282,6 @@ class NonIntegerVotes(RowTest):
     def _test_row(self, row: list[str]):
         if len(row) == len(self.__headers):
             for value in (row[i] for i in self.__indices_to_check):
-                # There are some rare cases where the value represents a turnout percentage.  We will try and avoid
-                # these rows.
-                percentages = {"%", "pct", "percent"}
-                if self.__candidate_index is not None \
-                        and any(x in row[self.__candidate_index].lower() for x in percentages):
-                    continue
-
                 # If the value isn't numeric, skip the test.  This can be due to the row having an inconsistent
                 # number of columns (hence the index of the "votes" column is invalid), or the value has been
                 # redacted and is represented by a non-numeric character.
@@ -288,9 +290,29 @@ class NonIntegerVotes(RowTest):
                 except ValueError:
                     continue
 
-                # This allows for "3" and "3.0", but not "3.1".
-                if not float(float_value).is_integer():
+                candidate = None if self.__candidate_index is None else row[self.__candidate_index]
+                if self._is_bad_value(candidate, float(value)):
                     self.__failures[self.current_row] = row
+
+
+class NonIntegerVotes(VotesTest):
+    def __init__(self, headers: list[str]):
+        super().__init__(headers)
+
+    @property
+    def _failure_description(self) -> str:
+        return "aren't integers"
+
+    def _is_bad_value(self, candidate: str, value: float) -> bool:
+        # There are some rare cases where the value represents a turnout percentage.  We will try and avoid
+        # these rows.
+        if candidate is not None:
+            percentages = {"%", "pct", "percent"}
+            if any(x in candidate.lower() for x in percentages):
+                return False
+
+        # This allows for "3" and "3.0", but not "3.1".
+        return not value.is_integer()
 
 
 class LeadingAndTrailingSpaces(ValueTest):

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -127,6 +127,7 @@ class FileFormatTests(TestCase):
                     headers = next(reader)
 
                     tests.add(format_tests.InconsistentNumberOfColumns(headers))
+                    tests.add(format_tests.NegativeVotes(headers))
                     tests.add(format_tests.NonIntegerVotes(headers))
 
                     for test in tests:

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -169,6 +169,41 @@ class LowercaseHeadersTest(unittest.TestCase):
         self.assertRegex(failure_message, re.escape(f"{header}") + ".*lowercase")
 
 
+class NegativeVotesTest(unittest.TestCase):
+    def test_empty(self):
+        format_test = format_tests.NegativeVotes(["a", "b", "c"])
+        self.assertTrue(format_test.passed)
+
+    def test_headers(self):
+        format_test = format_tests.NegativeVotes(["a", "b", "c"])
+        format_test.test(["a", "-1", "c"])
+        self.assertTrue(format_test.passed)
+
+        format_test = format_tests.NegativeVotes(["a", "Percentage", "c"])
+        format_test.test(["a", "-1", "c"])
+        self.assertTrue(format_test.passed)
+
+        good_values = ["*", "0", "2", "2.2"]
+        format_test = format_tests.NegativeVotes(["a", "votes", "c"])
+        for value in good_values:
+            format_test.test(["a", value, "c"])
+            self.assertTrue(format_test.passed)
+
+        bad_values = ["-1", "-1.2", "-0.01"]
+        vote_columns = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
+        for column in vote_columns:
+            for value in bad_values:
+                bad_row = ["a", 1, value, "c"]
+                format_test = format_tests.NegativeVotes(["a", "votes ", column, "c"])
+                format_test.test(["a", 1, 2, "c"])
+                format_test.test(bad_row)
+                self.assertFalse(format_test.passed)
+
+                failure_message = format_test.get_failure_message()
+                self.assertNotRegex(failure_message, "Row 1.*")
+                self.assertRegex(failure_message, f"Row 2.*" + re.escape(f"{bad_row}"))
+
+
 class NonIntegerVotesTest(unittest.TestCase):
     def test_empty(self):
         format_test = format_tests.NonIntegerVotes(["a", "b", "c"])

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -345,6 +345,7 @@ class RunTestsTest(unittest.TestCase):
         ["", "", "", "", ""],  # Empty rows
         ["a", "b  c", "1", "2", "3"],  # Consecutive whitespace
         ["a", "b", "c", "1", "2", "3"],  # Inconsistent number of columns
+        ["a", "b", "1", "-2", "3"],  # Negative votes
         ["a", "b", "1", "2.5", "3"],  # Non-integer votes
         [" a", "b", "1", "2", "3"],  # Leading whitespace
         ["a ", "b", "1", "2", "3"],  # Trailing whitespace
@@ -416,6 +417,7 @@ class RunTestsTest(unittest.TestCase):
         self.assertRegex(log_file_contents, "1 empty rows")
         self.assertRegex(log_file_contents, "1 rows.*consecutive whitespace")
         self.assertRegex(log_file_contents, "1 rows.*inconsistent number of columns")
+        self.assertRegex(log_file_contents, "1 rows.*negative")
         self.assertRegex(log_file_contents, "1 rows.*integers")
         self.assertRegex(log_file_contents, "2 rows.*leading or trailing whitespace")
         self.assertRegex(log_file_contents, "1 rows.*newline characters")


### PR DESCRIPTION
This adds a test to detect the presence of negative vote values.  There are a few cases that will be ignored (e.g., over/under votes, and non-float values).

This reveals the following failures in the data repositories:
<details><summary>openelections-data-ia</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/20181106__ia__general__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 18 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 41041: ['Guthrie', 'White', 'Union Township Trustee', '', '', 'Write-in', '0', '-4', '4']
	Row 41044: ['Guthrie', 'White', 'Union Township Clerk', '', '', 'Write-in', '0', '-1', '1']
	Row 41053: ['Guthrie', 'Gold', 'Valley Township Clerk', '', '', 'Write-in', '2', '-2', '4']
	Row 45560: ['Howard', 'Albion/Forest City', 'Forest City Township Trustee', '', '', 'Kevin Groenwold', '-1', '-1', '0']
	Row 45561: ['Howard', 'Albion/Forest City', 'Forest City Township Trustee', '', '', 'Randy Cray', '-1', '-1', '0']
	Row 47840: ['Iowa', 'Dayton / English I', 'Dayton Township Trustee', '', '', 'Write-in', '0', '-7', '7']
	Row 47846: ['Iowa', 'Dayton / English I', 'Dayton Township Clerk', '', '', 'Write-in', '0', '-2', '2']
	Row 112596: ['Taylor', 'Bedford Township - Legion', 'Jackson Township Trustee', '', '', 'Write-in', '0', '-1', '1']
	Row 112633: ['Taylor', 'Lenox', 'Platte Township Trustee', '', '', 'Write-in', '0', '-1', '1']
	Row 117304: ['Warren', 'Palmyra', 'Soil & Water Conservation District Commisioners', '01-01-2019 thru 12-31-2022', '', 'Write-in', '1', '-1', '2']
	[Truncated to 10 examples]

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__warren__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 1603: ['Warren', 'Palmyra', 'Soil & Water Conservation District Commisioners', '01-01-2019 thru 12-31-2022', '', 'Write-in', '1', '-1', '2']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__winnebago__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 8 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 1466: ['Winnebago', 'Buffalo Grant Lincoln', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-6', '6']
	Row 1467: ['Winnebago', 'Center', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-4', '4']
	Row 1469: ['Winnebago', 'FC3 Forest D3', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-4', '4']
	Row 1470: ['Winnebago', 'Forest City Ward 1', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-4', '4']
	Row 1471: ['Winnebago', 'Forest City Ward 2', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-5', '5']
	Row 1472: ['Winnebago', 'Forest City Ward 4', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-6', '6']
	Row 1473: ['Winnebago', 'King Linden', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-2', '2']
	Row 1474: ['Winnebago', 'Mt. Valley Forest D2', 'County Agricultural Extension Council Members', '', '', 'Write-in', '0', '-9', '9']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__taylor__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 321: ['Taylor', 'Bedford Township - Legion', 'Jackson Township Trustee', '', '', 'Write-in', '0', '-1', '1']
	Row 358: ['Taylor', 'Lenox', 'Platte Township Trustee', '', '', 'Write-in', '0', '-1', '1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__guthrie__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 3 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 375: ['Guthrie', 'White', 'Union Township Trustee', '', '', 'Write-in', '0', '-4', '4']
	Row 378: ['Guthrie', 'White', 'Union Township Clerk', '', '', 'Write-in', '0', '-1', '1']
	Row 387: ['Guthrie', 'Gold', 'Valley Township Clerk', '', '', 'Write-in', '2', '-2', '4']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__howard__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 373: ['Howard', 'Albion/Forest City', 'Forest City Township Trustee', '', '', 'Kevin Groenwold', '-1', '-1', '0']
	Row 374: ['Howard', 'Albion/Forest City', 'Forest City Township Trustee', '', '', 'Randy Cray', '-1', '-1', '0']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__ia__general__iowa__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes', 'election_day', 'absentee']:
	Row 522: ['Iowa', 'Dayton / English I', 'Dayton Township Trustee', '', '', 'Write-in', '0', '-7', '7']
	Row 528: ['Iowa', 'Dayton / English I', 'Dayton Township Clerk', '', '', 'Write-in', '0', '-2', '2']

----------------------------------------------------------------------
Ran 1 test in 7.638s

FAILED (failures=7)
</details>

<details><summary>openelections-data-il</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2014/20141104__il__general__precinct.csv] (group='2014')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'EISCandidateID', 'candidate', 'votes']:
	Row 214948: ['ST. CLAIR', 'St Clair 24', 'Governor', '', 'NonPartisan', '50004', 'Write-in', '-1']
	Row 217185: ['ST. CLAIR', 'St Clair 12', 'State Comptroller', '', 'NonPartisan', '50003', 'Write-in', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2016/20161108__il__general__precinct.csv] (group='2016')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 4 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 28891: ['ST. CLAIR', 'St Clair 25', 'President', '', 'NonPartisan', 'Write-in', '-238']
	Row 34890: ['ST. CLAIR', 'Belleville 35', 'President', '', 'NonPartisan', 'Write-in', '-24']
	Row 76966: ['ST. CLAIR', 'St Clair 25', 'President', '', 'NonPartisan', 'Write-in', '-238']
	Row 82965: ['ST. CLAIR', 'Belleville 35', 'President', '', 'NonPartisan', 'Write-in', '-24']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2016/counties/20161108__il__general__st_clair__precinct.csv] (group='2016')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 2091: ['ST. CLAIR', 'St Clair 25', 'President', '', 'NonPartisan', 'Write-in', '-238']
	Row 2615: ['ST. CLAIR', 'Belleville 35', 'President', '', 'NonPartisan', 'Write-in', '-24']

----------------------------------------------------------------------
Ran 1 test in 11.299s

FAILED (failures=3)
</details>

<details><summary>openelections-data-in</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/20181106__in__general__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'absentee', 'election_day', 'provisional', 'early_voting']:
	Row 25480: ['Gibson', 'PAT8', 'Auditor of State', '', 'Cast Votes', '', '130', '', '-79', '', '51']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__in__general__gibson__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'early_voting', 'election_day', 'votes']:
	Row 769: ['Gibson', 'PAT8', 'Auditor of State', '', 'Cast Votes', '', '51', '-79', '130']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2014/20141104__in__general__precinct.csv] (group='2014')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
	Row 41697: ['Ripley', 'Washington 1', 'Auditor', '', 'John Schick', 'L', '-13']
	Row 47538: ['Tippecanoe', 'Wea 07', 'Treasurer', '', 'Kelly Mitchell', 'R', '-154']

----------------------------------------------------------------------
Ran 1 test in 5.161s

FAILED (failures=3)
</details>

<details><summary>openelections-data-ma</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2020/20200303__ma__primary__president__precinct.csv] (group='2020')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['town', 'ward', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 24431: ['Sturbridge', '', '3', 'President', '', 'Democratic', 'All Others', '-4']

----------------------------------------------------------------------
Ran 1 test in 10.455s

FAILED (failures=1)
</details>

<details><summary>openelections-data-mi</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2000/20001107__mi__general__precinct.csv] (group='2000')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 8 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 2855: ['Arenac', '9999', 'President', '', '', 'Ralph Nader', '-2']
	Row 2861: ['Arenac', '9999', 'U.S. Senate', '', '', 'Mark A. Forton', '-2']
	Row 2866: ['Arenac', '9999', 'State House', '103', '', 'Dale Sheltrown', '-1']
	Row 10305: ['Charlevoix', '9999', 'President', '', '', 'Patrick J. Buchanan', '-10']
	Row 15808: ['Emmet', '9999', 'President', '', '', 'Patrick J. Buchanan', '-1']
	Row 36390: ['Kalamazoo', '9999', 'U.S. House', '6', '', 'William Bradley', '-3']
	Row 61374: ['Missaukee', '9999', 'State House', '102', '', 'Paul D. Williamson Ii', '-2']
	Row 129907: ['Wayne', '9999', 'President', '', '', 'Patrick J. Buchanan', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/20181106__mi__general__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 5 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 42889: ['Genesee', '9999', 'U.S. Senate', '', 'NLP', 'John Howard Wilhelm', '-16']
	Row 55767: ['Ingham', '9999', 'State House', '67', 'LIB', 'Zachary Moreau', '-1']
	Row 55768: ['Ingham', '9999', 'State House', '69', 'DEM', 'Julie Brixie', '-2']
	Row 60136: ['Isabella', '9999', 'State House', '99', 'REP', 'Roger Hauck', '-16']
	Row 60137: ['Isabella', '9999', 'State House', '99', 'DEM', 'Kristen Brown', '-4']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2012/20121106__mi__general__precinct.csv] (group='2012')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 4 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 7019: ['Berrien', '9999', 'U.S. House', '6', 'LIB', 'Christie Gelineau', '-1']
	Row 32940: ['Isabella', '9999', 'State House', '99', 'REP', 'Kevin Cotter', '-10']
	Row 32941: ['Isabella', '9999', 'State House', '99', 'DEM', 'Adam Lawrence', '-5']
	Row 85446: ['Otsego', '9999', 'President', '', 'NPA', 'Gary Johnson', '-23']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2006/20061107__mi__general__precinct.csv] (group='2006')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 39 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 10221: ['Berrien', '9999', 'Governor', '', '', 'Jennifer M. Granholm', '-1']
	Row 10222: ['Berrien', '9999', 'Governor', '', '', 'Dick Devos', '-3']
	Row 10228: ['Berrien', '9999', 'Secretary of State', '', '', 'Terri Lynn Land', '-2']
	Row 10230: ['Berrien', '9999', 'Secretary of State', '', '', 'Carmella Sabaugh', '-1']
	Row 10231: ['Berrien', '9999', 'Attorney General', '', '', 'Mike Cox', '-2']
	Row 10232: ['Berrien', '9999', 'Attorney General', '', '', 'Amos Williams', '-1']
	Row 10233: ['Berrien', '9999', 'Attorney General', '', '', 'Bill Hall', '-1']
	Row 10240: ['Berrien', '9999', 'U.S. Senate', '', '', 'Leonard Schwartz', '-4']
	Row 10241: ['Berrien', '9999', 'U.S. Senate', '', '', 'Debbie Stabenow', '-1']
	Row 10242: ['Berrien', '9999', 'U.S. Senate', '', '', 'Michael Bouchard', '-2']
	[Truncated to 10 examples]

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2014/20141104__mi__general__precinct.csv] (group='2014')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 5 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 14154: ['Cass', '9999', 'Attorney General', '', 'GRN', 'John Anthony La Pietra', '-1']
	Row 14164: ['Cass', '9999', 'U.S. Senate', '', 'REP', 'Terri Lynn Land', '-2']
	Row 88425: ['Mecosta', '9999', 'Governor', '', 'NLP', 'Patrick Groulx', '-3']
	Row 88426: ['Mecosta', '9999', 'U.S. Senate', '', 'NPA', 'Robert G. Boensch', '-6']
	Row 91028: ['Midland', '9999', 'Governor', '', 'NLP', 'Patrick Groulx', '-11']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2016/20161108__mi__general__precinct.csv] (group='2016')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 20084: ['Huron', '9999', 'President', '', 'DEM', 'Hillary Clinton', '-2']
	Row 20086: ['Huron', '9999', 'President', '', 'REP', 'Donald J. Trump', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2010/20101102__mi__general__precinct.csv] (group='2010')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 118903: ['Saginaw', '9999', 'State Senate', '32', 'REP', 'Roger Kahn', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2008/20081104__mi__general__precinct.csv] (group='2008')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 6 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 27637: ['Ionia', '9999', 'President', '', 'DEM', 'Barack Obama', '-91']
	Row 33614: ['Kalkaska', '9999', 'President', '', 'REP', 'John Mccain', '-1']
	Row 33624: ['Kalkaska', '9999', 'U.S. Senate', '', 'REP', 'Jack Hoogendyk, Jr.', '-1']
	Row 33627: ['Kalkaska', '9999', 'U.S. House', '4', 'REP', 'Dave Camp', '-1']
	Row 33629: ['Kalkaska', '9999', 'State House', '104', 'REP', 'Wayne A. Schmidt', '-1']
	Row 60772: ['Montcalm', '9999', 'U.S. Senate', '', 'GRN', 'Harley G. Mikkelson', '-2']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2004/20041102__mi__general__precinct.csv] (group='2004')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 7 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 4676: ['Berrien', '9999', 'U.S. House', '6', '', 'Fred Upton', '-1']
	Row 9814: ['Emmet', '9999', 'State House', '107', '', 'Gary Mcdowell', '-1']
	Row 22490: ['Kalkaska', '9999', 'President', '', '', 'George W. Bush', '-7']
	Row 53928: ['Shiawassee', '9999', 'President', '', '', 'Walter Brown', '-9']
	Row 78707: ['Wayne', '9999', 'President', '', '', 'John F. Kerry', '-11']
	Row 78709: ['Wayne', '9999', 'President', '', '', 'Michael Badnarik', '-72']
	Row 78710: ['Wayne', '9999', 'President', '', '', 'David Cobb', '-496']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2020/20201103__mi__general__precinct.csv] (group='2020')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 74 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 4688: ['Bay', '9999', 'President', '', 'REP', 'Donald J. Trump', '-32']
	Row 4689: ['Bay', '9999', 'President', '', 'DEM', 'Joseph R. Biden', '-35']
	Row 4692: ['Bay', '9999', 'President', '', 'LIB', 'Jo Jorgensen', '-3']
	Row 4693: ['Bay', '9999', 'President', '', 'GRN', 'Howie Hawkins', '-1']
	Row 4698: ['Bay', '9999', 'U.S. Senate', '', 'GRN', 'Marcia Squier', '-1']
	Row 4699: ['Bay', '9999', 'U.S. Senate', '', 'DEM', 'Gary Peters', '-32']
	Row 4700: ['Bay', '9999', 'U.S. Senate', '', 'REP', 'John James', '-37']
	Row 4701: ['Bay', '9999', 'U.S. House', '5', 'WCP', 'Kathy Goodwin', '-3']
	Row 4702: ['Bay', '9999', 'U.S. House', '5', 'LIB', 'James Harris', '-2']
	Row 4703: ['Bay', '9999', 'U.S. House', '5', 'REP', 'Tim Kelly', '-32']
	[Truncated to 10 examples]

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2002/20021105__mi__general__precinct.csv] (group='2002')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 7 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 646: ['Alcona', '9999', 'State Senate', '36', '', 'Tony Stamas', '-8']
	Row 32409: ['Houghton', '9999', 'Governor', '', '', 'Douglas Campbell', '-2']
	Row 47839: ['Kalkaska', '9999', 'State Senate', '35', '', 'Carl Dahlberg', '-100']
	Row 85053: ['Montmorency', '9999', 'U.S. Senate', '', '', 'John S. Mangopoulos', '-1']
	Row 109442: ['Otsego', '9999', 'Attorney General', '', '', 'Gerald Truman Van Sickle', '-10']
	Row 123430: ['Tuscola', '9999', 'Governor', '', '', 'Douglas Campbell', '-2']
	Row 123445: ['Tuscola', '9999', 'U.S. House', '5', '', 'Thom Moffitt', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [1998/19981103__mi__general__precinct.csv] (group='1998')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 3 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 35675: ['Jackson', '9999', 'Governor', '', '', 'Geoffrey Fieger', '-6']
	Row 85592: ['Oscoda', '9999', 'State House', '105', '', 'Ken Bradstreet', '-253']
	Row 96266: ['Tuscola', '9999', 'Governor', '', '', 'Geoffrey Fieger', '-5']

----------------------------------------------------------------------
Ran 1 test in 9.529s

FAILED (failures=12)
</details>

<details><summary>openelections-data-mo</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2008/20081104__mo__general__precinct.csv] (group='2008')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'last_name', 'first_name', 'votes']:
	Row 78363: ['ST LOUIS CITY', '9999Recount Differential', 'State Senate', '1', 'REP', 'Lembke', 'James', '-8']

----------------------------------------------------------------------
Ran 1 test in 6.308s

FAILED (failures=1)
</details>

<details><summary>openelections-data-ny</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2016/20161108__ny__general__precinct.csv] (group='2016')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'election_day', 'absentee', 'machine_votes', 'absentee_hc', 'affidavit']:
	Row 672865: ['Suffolk', 'Babylon #: 14', 'President', '', 'Scattering', '', '-1', '', '', '', '', '']
	Row 672967: ['Suffolk', 'Babylon #: 116', 'President', '', 'Scattering', '', '-1', '', '', '', '', '']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2016/counties/20161108__ny__general__suffolk__precinct.csv] (group='2016')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 2 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'party', 'candidate', 'votes']:
	Row 21055: ['Suffolk', 'Babylon #: 14', 'President', '', '', 'Scattering', '-1']
	Row 21157: ['Suffolk', 'Babylon #: 116', 'President', '', '', 'Scattering', '-1']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2020/20201103__ny__general__precinct.csv] (group='2020')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'election_day', 'absentee', 'early_voting', 'machine_votes', 'absentee_hc', 'affidavit']:
	Row 89866: ['Monroe', 'Webster 1', 'President', '', 'Blanks/Voids', '', '-1', '', '', '', '', '', '']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2020/counties/20201103__ny__general__monroe__precinct.csv] (group='2020')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes']:
	Row 19396: ['Monroe', 'Webster 1', 'President', '', 'Blank and Void', '', '-1']

----------------------------------------------------------------------
Ran 1 test in 48.823s

FAILED (failures=4)
</details>

<details><summary>openelections-data-tx</summary>

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/20181106__tx__general__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'absentee', 'election_day', 'early_voting', 'mail', 'provisional', 'limited']:
	Row 130955: ['Lamb', '4 - Sudan Community', 'Railroad Commissioner', '', 'Roman McAllen', 'DEM', '0', '', '-9', '0', '', '', '']

======================================================================
FAIL: test_format (data_tests.test_data.FileFormatTests) [2018/counties/20181106__tx__general__lamb__precinct.csv] (group='2018')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 154, in test_format
    self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
  File "/home/ken/documents/code/openelections/openelections-data-tests/data_tests/test_data.py", line 60, in _assertTrue
    self.assertTrue(result, short_message)
AssertionError: False is not true : 

* There are 1 rows with votes that are negative:

	Headers: ['county', 'precinct', 'office', 'district', 'candidate', 'party', 'votes', 'early_voting', 'mail', 'election_day']:
	Row 313: ['Lamb', '4 - Sudan Community', 'Railroad Commissioner', '', 'Roman McAllen', 'DEM', '0', '0', '9', '-9']

----------------------------------------------------------------------
Ran 1 test in 107.002s

FAILED (failures=2)
</details>
