### PR TITLE
Avoid name mangling to hide members

### DIFF
--- a/data_tests/duplicate_entries.py
+++ b/data_tests/duplicate_entries.py
@@ -2,32 +2,32 @@ import re
 
 
 class DuplicateEntries:
-    __non_whitespace_regex = re.compile(r"\S")
+    _non_whitespace_regex = re.compile(r"\S")
 
     def __init__(self, headers: list[str]):
         super().__init__()
-        self.__current_row = 0
-        self.__hash_to_row_map = {}
-        self.__passed = True
-        self.__headers = headers
+        self._current_row = 0
+        self._hash_to_row_map = {}
+        self._passed = True
+        self._headers = headers
 
         indices_to_hash = []
-        for i, x in enumerate(self.__headers):
+        for i, x in enumerate(self._headers):
             lowered_header = x.lower()
             not_vote_column = "votes" not in lowered_header
             not_vote_column &= lowered_header not in {"absentee", "early_voting", "election_day", "mail", "provisional"}
             if not_vote_column:
                 indices_to_hash.append(i)
 
-        self.__indices_to_hash = indices_to_hash
+        self._indices_to_hash = indices_to_hash
 
     @property
     def passed(self) -> bool:
-        return self.__passed
+        return self._passed
 
-    def __hash_row(self, row: list[str]) -> int:
-        if len(row) == len(self.__headers):
-            entries_to_hash = (row[i] for i in self.__indices_to_hash)
+    def _hash_row(self, row: list[str]) -> int:
+        if len(row) == len(self._headers):
+            entries_to_hash = (row[i] for i in self._indices_to_hash)
         else:
             entries_to_hash = row
 
@@ -35,23 +35,23 @@ class DuplicateEntries:
         return hash(tuple(hashed_entries))
 
     @staticmethod
-    def __is_empty(row: list) -> bool:
+    def _is_empty(row: list) -> bool:
         has_content = False
         for entry in row:
-            has_content |= bool(DuplicateEntries.__non_whitespace_regex.search(entry))
+            has_content |= bool(DuplicateEntries._non_whitespace_regex.search(entry))
 
         return not has_content
 
     def get_failure_message(self, max_examples: int = -1) -> str:
         num_duplicates = 0
-        for _, rows in self.__hash_to_row_map.items():
+        for _, rows in self._hash_to_row_map.items():
             if len(rows) > 1:
                 num_duplicates += len(rows) - 1
 
         message = f"{num_duplicates} duplicate entries detected:\n\n" \
-                  f"\tHeaders: {self.__headers}:"
+                  f"\tHeaders: {self._headers}:"
         count = 0
-        for row_hash, row_map in self.__hash_to_row_map.items():
+        for row_hash, row_map in self._hash_to_row_map.items():
             if len(row_map) > 1:
                 for row_number, row in row_map.items():
                     if (max_examples >= 0) and (count >= max_examples):
@@ -64,11 +64,11 @@ class DuplicateEntries:
         return message
 
     def test(self, row: list):
-        self.__current_row += 1
-        if not DuplicateEntries.__is_empty(row):
-            row_hash = self.__hash_row(row)
-            if row_hash in self.__hash_to_row_map:
-                self.__passed = False
-                self.__hash_to_row_map[row_hash][self.__current_row] = row
+        self._current_row += 1
+        if not DuplicateEntries._is_empty(row):
+            row_hash = self._hash_row(row)
+            if row_hash in self._hash_to_row_map:
+                self._passed = False
+                self._hash_to_row_map[row_hash][self._current_row] = row
             else:
-                self.__hash_to_row_map[row_hash] = {self.__current_row: row}
+                self._hash_to_row_map[row_hash] = {self._current_row: row}

--- a/data_tests/format_tests.py
+++ b/data_tests/format_tests.py
@@ -21,14 +21,14 @@ class FormatTest(ABC):
 class RowTest(FormatTest):
     def __init__(self):
         super().__init__()
-        self.__current_row = 0
+        self._current_row = 0
 
     @property
     def current_row(self) -> int:
-        return self.__current_row
+        return self._current_row
 
     def test(self, value):
-        self.__current_row += 1
+        self._current_row += 1
         self._test_row(value)
 
     @abstractmethod
@@ -39,7 +39,7 @@ class RowTest(FormatTest):
 class ValueTest(RowTest):
     def __init__(self):
         super().__init__()
-        self.__failures = {}
+        self._failures = {}
 
     @property
     @abstractmethod
@@ -48,12 +48,12 @@ class ValueTest(RowTest):
 
     @property
     def passed(self):
-        return len(self.__failures) == 0
+        return len(self._failures) == 0
 
     def get_failure_message(self, max_examples=-1):
-        message = f"There are {len(self.__failures)} rows that have entries with {self.description}:\n"
+        message = f"There are {len(self._failures)} rows that have entries with {self.description}:\n"
         count = 0
-        for key, value in self.__failures.items():
+        for key, value in self._failures.items():
             if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
                 return message
@@ -70,81 +70,81 @@ class ValueTest(RowTest):
     def _test_row(self, row: list[str]):
         for entry in row:
             if self.is_bad_value(entry):
-                self.__failures[self.current_row] = row
+                self._failures[self.current_row] = row
                 break
 
 
 class EmptyHeaders(FormatTest):
     def __init__(self):
         super().__init__()
-        self.__headers = []
-        self.__passed = True
+        self._headers = []
+        self._passed = True
 
     @property
     def passed(self):
-        return self.__passed
+        return self._passed
 
     def get_failure_message(self, max_examples=0):
-        return f"Header {self.__headers} has empty entries."
+        return f"Header {self._headers} has empty entries."
 
     def test(self, headers: list[str]):
-        self.__headers = headers
-        self.__passed = "" not in headers
+        self._headers = headers
+        self._passed = "" not in headers
 
 
 class LowercaseHeaders(FormatTest):
     def __init__(self):
         super().__init__()
-        self.__headers = []
-        self.__passed = True
+        self._headers = []
+        self._passed = True
 
     @property
     def passed(self):
-        return self.__passed
+        return self._passed
 
     def get_failure_message(self, max_examples=0):
-        return f"Header {self.__headers} should only contain lowercase characters."
+        return f"Header {self._headers} should only contain lowercase characters."
 
     def test(self, headers: list[str]):
-        self.__headers = headers
-        self.__passed = headers == [x.lower() for x in headers]
+        self._headers = headers
+        self._passed = headers == [x.lower() for x in headers]
 
 
 class MissingHeaders(FormatTest):
     def __init__(self, required_headers: set[str]):
         super().__init__()
-        self.__headers = []
-        self.__passed = True
-        self.__required_headers = required_headers
+        self._headers = []
+        self._passed = True
+        self._required_headers = required_headers
 
     @property
     def passed(self):
-        return self.__passed
+        return self._passed
 
     def get_failure_message(self, max_examples=0):
-        return f"Header {self.__headers} is missing entries: {self.__required_headers.difference(self.__headers)}."
+        return f"Header {self._headers} is missing entries: {self._required_headers.difference(self._headers)}."
 
     def test(self, headers: list[str]):
-        self.__headers = headers
-        self.__passed = self.__required_headers.issubset(headers)
+        self._headers = headers
+        self._passed = self._required_headers.issubset(headers)
 
 
 class UnknownHeaders(FormatTest):
     def __init__(self):
         super().__init__()
-        self.__headers = []
-        self.__passed = True
+        self._headers = []
+        self._passed = True
 
     @property
     def passed(self):
-        return self.__passed
+        return self._passed
 
     def get_failure_message(self, max_examples=0):
-        return f"Header {self.__headers} has unknown entries."
+        return f"Header {self._headers} has unknown entries."
 
     def test(self, headers: list[str]):
-        self.__headers = headers
-        self.__passed = "unknown" not in [x.strip().lower() for x in headers]
+        self._headers = headers
+        self._passed = "unknown" not in [x.strip().lower() for x in headers]
 
 
 class WhitespaceInHeaders(FormatTest):
@@ -152,19 +152,19 @@ class WhitespaceInHeaders(FormatTest):
 
     def __init__(self):
         super().__init__()
-        self.__headers = []
-        self.__passed = True
+        self._headers = []
+        self._passed = True
 
     @property
     def passed(self):
-        return self.__passed
+        return self._passed
 
     def get_failure_message(self, max_examples=0):
-        return f"Header {self.__headers} contains whitespace characters."
+        return f"Header {self._headers} contains whitespace characters."
 
     def test(self, headers: list[str]):
-        self.__headers = headers
-        self.__passed = not any(bool(WhitespaceInHeaders.regex.search(x)) for x in self.__headers)
+        self._headers = headers
+        self._passed = not any(bool(WhitespaceInHeaders.regex.search(x)) for x in self._headers)
 
 
 class ConsecutiveSpaces(ValueTest):
@@ -183,14 +183,14 @@ class EmptyRows(RowTest):
 
     def __init__(self):
         super().__init__()
-        self.__empty_row_count = 0
+        self._empty_row_count = 0
 
     @property
     def passed(self):
-        return self.__empty_row_count == 0
+        return self._empty_row_count == 0
 
     def get_failure_message(self, max_examples=0):
-        return f"Has {self.__empty_row_count} empty rows."
+        return f"Has {self._empty_row_count} empty rows."
 
     def _test_row(self, row: list[str]):
         has_content = False
@@ -198,26 +198,26 @@ class EmptyRows(RowTest):
             has_content |= bool(EmptyRows.regex.search(entry))
 
         if not has_content:
-            self.__empty_row_count += 1
+            self._empty_row_count += 1
 
 
 class InconsistentNumberOfColumns(RowTest):
     def __init__(self, headers):
         super().__init__()
-        self.__failures = {}
-        self.__headers = headers
+        self._failures = {}
+        self._headers = headers
 
     @property
     def passed(self):
-        return len(self.__failures) == 0
+        return len(self._failures) == 0
 
     def get_failure_message(self, max_examples=-1):
-        message = f"Header has {len(self.__headers)} entries, but there are {len(self.__failures)} " \
+        message = f"Header has {len(self._headers)} entries, but there are {len(self._failures)} " \
                   f"rows with an inconsistent number of columns:\n\n" \
-                  f"\tHeaders ({len(self.__headers)} entries): {self.__headers}:"
+                  f"\tHeaders ({len(self._headers)} entries): {self._headers}:"
 
         count = 0
-        for key, value in self.__failures.items():
+        for key, value in self._failures.items():
             if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
                 return message
@@ -228,15 +228,15 @@ class InconsistentNumberOfColumns(RowTest):
         return message
 
     def _test_row(self, row: list[str]):
-        if len(row) != len(self.__headers):
-            self.__failures[self.current_row] = row
+        if len(row) != len(self._headers):
+            self._failures[self.current_row] = row
 
 
 class VotesTest(RowTest):
     def __init__(self, headers: list[str]):
         super().__init__()
-        self.__failures = {}
-        self.__headers = headers
+        self._failures = {}
+        self._headers = headers
 
         columns_to_check = {"absentee", "early_voting", "election_day", "mail", "provisional", "votes"}
         lowercase_headers = [x.strip().lower() for x in headers]
@@ -244,12 +244,12 @@ class VotesTest(RowTest):
         for index, header in enumerate(lowercase_headers):
             if header in columns_to_check:
                 indices_to_check.append(index)
-        self.__indices_to_check = indices_to_check
+        self._indices_to_check = indices_to_check
 
         if "candidate" in lowercase_headers:
-            self.__candidate_index = lowercase_headers.index("candidate")
+            self._candidate_index = lowercase_headers.index("candidate")
         else:
-            self.__candidate_index = None
+            self._candidate_index = None
 
     @property
     @abstractmethod
@@ -258,18 +258,18 @@ class VotesTest(RowTest):
 
     @property
     def passed(self) -> bool:
-        return len(self.__failures) == 0
+        return len(self._failures) == 0
 
     @abstractmethod
     def _is_bad_value(self, candidate: str, value: float) -> bool:
         raise NotImplementedError()
 
     def get_failure_message(self, max_examples=-1) -> str:
-        message = f"There are {len(self.__failures)} rows with votes that {self._failure_description}:\n\n" \
-                  f"\tHeaders: {self.__headers}:"
+        message = f"There are {len(self._failures)} rows with votes that {self._failure_description}:\n\n" \
+                  f"\tHeaders: {self._headers}:"
 
         count = 0
-        for key, value in self.__failures.items():
+        for key, value in self._failures.items():
             if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
                 return message
@@ -280,8 +280,8 @@ class VotesTest(RowTest):
         return message
 
     def _test_row(self, row: list[str]):
-        if len(row) == len(self.__headers):
-            for value in (row[i] for i in self.__indices_to_check):
+        if len(row) == len(self._headers):
+            for value in (row[i] for i in self._indices_to_check):
                 # If the value isn't numeric, skip the test.  This can be due to the row having an inconsistent
                 # number of columns (hence the index of the "votes" column is invalid), or the value has been
                 # redacted and is represented by a non-numeric character.
@@ -290,9 +290,9 @@ class VotesTest(RowTest):
                 except ValueError:
                     continue
 
-                candidate = None if self.__candidate_index is None else row[self.__candidate_index]
+                candidate = None if self._candidate_index is None else row[self._candidate_index]
                 if self._is_bad_value(candidate, float(value)):
-                    self.__failures[self.current_row] = row
+                    self._failures[self.current_row] = row
 
 
 class NegativeVotes(VotesTest):

--- a/data_tests/inconsistencies.py
+++ b/data_tests/inconsistencies.py
@@ -1,45 +1,45 @@
 class VoteBreakdownTotals:
     def __init__(self, headers: list[str]):
-        self.__headers = headers
-        self.__failures = {}
-        self.__current_row = 0
+        self._headers = headers
+        self._failures = {}
+        self._current_row = 0
 
         votes = "votes"
-        if votes in self.__headers:
-            self.__votes_index = self.__headers.index(votes)
+        if votes in self._headers:
+            self._votes_index = self._headers.index(votes)
         else:
-            self.__votes_index = None
+            self._votes_index = None
 
-        if "candidate" in self.__headers:
-            self.__candidate_index = self.__headers.index("candidate")
+        if "candidate" in self._headers:
+            self._candidate_index = self._headers.index("candidate")
         else:
-            self.__candidate_index = None
+            self._candidate_index = None
 
         components = {"absentee", "early_voting", "election_day", "mail", "provisional"}
-        self.__component_indices = [i for i, x in enumerate(self.__headers) if x in components]
+        self._component_indices = [i for i, x in enumerate(self._headers) if x in components]
 
         # If the column headers match some known schemas, we can check for exact equality.
         known_schemas = [
             {"county", "precinct", "office", "district", "party", "candidate", "votes", "early_voting", "election_day",
              "provisional", "mail"}
         ]
-        self.__check_equality = set(self.__headers) in known_schemas
+        self._check_equality = set(self._headers) in known_schemas
 
     @property
     def passed(self) -> bool:
-        return len(self.__failures) == 0
+        return len(self._failures) == 0
 
     def get_failure_message(self, max_examples: int = -1) -> str:
-        components = [self.__headers[i] for i in self.__component_indices]
-        if self.__check_equality:
+        components = [self._headers[i] for i in self._component_indices]
+        if self._check_equality:
             relation = "not equal to"
         else:
             relation = "greater than"
-        message = f"There are {len(self.__failures)} rows where the sum of {components} is {relation} 'votes':\n\n" \
-                  f"\tHeaders: {self.__headers}:"
+        message = f"There are {len(self._failures)} rows where the sum of {components} is {relation} 'votes':\n\n" \
+                  f"\tHeaders: {self._headers}:"
 
         count = 0
-        for row_number, row in self.__failures.items():
+        for row_number, row in self._failures.items():
             if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
                 return message
@@ -50,25 +50,25 @@ class VoteBreakdownTotals:
         return message
 
     def test(self, row: list[str]):
-        self.__current_row += 1
+        self._current_row += 1
 
-        if (len(row) == len(self.__headers)) and self.__votes_index is not None and self.__component_indices:
+        if (len(row) == len(self._headers)) and self._votes_index is not None and self._component_indices:
             # There are cases where over votes and under votes are reported as a single aggregate.  As such, it's
             # possible for the votes to be negative.  We will try and avoid these rows.
-            if self.__candidate_index is not None:
+            if self._candidate_index is not None:
                 aggregates = {"over/under", "under/over"}
-                if any(x in row[self.__candidate_index].lower().replace(" ", "") for x in aggregates):
+                if any(x in row[self._candidate_index].lower().replace(" ", "") for x in aggregates):
                     return
 
             try:
                 # We use float instead of int to allow for values like "3.0".
-                votes = float(row[self.__votes_index])
+                votes = float(row[self._votes_index])
             except ValueError:
                 return
 
             component_sum = 0
             has_components = False
-            for component in (row[i] for i in self.__component_indices):
+            for component in (row[i] for i in self._component_indices):
                 try:
                     component_value = float(component)
                     has_components = True
@@ -77,8 +77,8 @@ class VoteBreakdownTotals:
                 component_sum += component_value
 
             if has_components:
-                if self.__check_equality:
+                if self._check_equality:
                     if votes != component_sum:
-                        self.__failures[self.__current_row] = row
+                        self._failures[self._current_row] = row
                 elif votes < component_sum:
-                    self.__failures[self.__current_row] = row
+                    self._failures[self._current_row] = row

--- a/data_tests/missing_values.py
+++ b/data_tests/missing_values.py
@@ -1,26 +1,26 @@
 class MissingValue:
     def __init__(self, required_value: str, headers: list[str]):
         super().__init__()
-        self.__current_row = 0
-        self.__required_value = required_value
-        self.__headers = headers
-        self.__failures = {}
+        self._current_row = 0
+        self._required_value = required_value
+        self._headers = headers
+        self._failures = {}
 
         if required_value in headers:
-            self.__required_value_index = headers.index(required_value)
+            self._required_value_index = headers.index(required_value)
         else:
-            self.__required_value_index = None
+            self._required_value_index = None
 
     @property
     def passed(self) -> bool:
-        return len(self.__failures) == 0
+        return len(self._failures) == 0
 
     def get_failure_message(self, max_examples: int = -1) -> str:
-        message = f"There are {len(self.__failures)} rows that are missing a {self.__required_value}:\n\n" \
-                  f"\tHeaders: {self.__headers}:"
+        message = f"There are {len(self._failures)} rows that are missing a {self._required_value}:\n\n" \
+                  f"\tHeaders: {self._headers}:"
 
         count = 0
-        for row_number, row in self.__failures.items():
+        for row_number, row in self._failures.items():
             if (max_examples >= 0) and (count >= max_examples):
                 message += f"\n\t[Truncated to {max_examples} examples]"
                 return message
@@ -31,11 +31,11 @@ class MissingValue:
         return message
 
     def test(self, row: list[str]):
-        self.__current_row += 1
-        if self.__required_value_index is not None:
-            if self.__required_value_index >= len(row):
-                self.__failures[self.__current_row] = row
+        self._current_row += 1
+        if self._required_value_index is not None:
+            if self._required_value_index >= len(row):
+                self._failures[self._current_row] = row
             else:
-                value = row[self.__required_value_index]
+                value = row[self._required_value_index]
                 if not value or value.isspace():
-                    self.__failures[self.__current_row] = row
+                    self._failures[self._current_row] = row

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -50,9 +50,9 @@ class TestCase(unittest.TestCase):
         super().__init__(*args, **kwargs)
 
         if TestCase.log_file is None:
-            self.__logger = None
+            self._logger = None
         else:
-            self.__logger = TestCase.__get_logger(type(self).__name__, TestCase.log_file)
+            self._logger = TestCase._get_logger(type(self).__name__, TestCase.log_file)
 
     def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
         if not result:
@@ -60,14 +60,14 @@ class TestCase(unittest.TestCase):
         self.assertTrue(result, short_message)
 
     def _log_failure(self, description: str, message: str):
-        if self.__logger is not None:
-            self.__logger.debug("======================================================================")
-            self.__logger.debug(f"FAIL: {description}")
-            self.__logger.debug("----------------------------------------------------------------------")
-            self.__logger.debug(f"{message}\n")
+        if self._logger is not None:
+            self._logger.debug("======================================================================")
+            self._logger.debug(f"FAIL: {description}")
+            self._logger.debug("----------------------------------------------------------------------")
+            self._logger.debug(f"{message}\n")
 
     @staticmethod
-    def __get_logger(name: str, log_file: str) -> logging.Logger:
+    def _get_logger(name: str, log_file: str) -> logging.Logger:
         handler = logging.FileHandler(log_file)
         handler.setFormatter(logging.Formatter("%(message)s"))
 


### PR DESCRIPTION
Hiding member access via name mangling goes against convention and makes debugging a bit more difficult.