### PR TITLE
Add option to limit tests to specific files

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.x
+        python-version: '3.10'
 
     - name: Check out code
       uses: actions/checkout@v2.3.4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: 3.x
 
     - name: Check out code
       uses: actions/checkout@v2.3.4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {file_format,duplicate_entries,missing_values,vote_breakdown_totals} root_path
+usage: run_tests.py [-h] [--files FILE [FILE ...]] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {file_format,duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
   {file_format,duplicate_entries,missing_values,vote_breakdown_totals}
@@ -14,6 +14,8 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  --files FILE [FILE ...]
+                        limit the tests to these specific files, specified relative to the root path
   --group-failures      group the failures by year in the console output using the GitHub Actions group and endgroup workflow commands
   --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
   --max-examples N      the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -36,6 +36,7 @@ class TestResult(unittest.TextTestResult):
 
 
 class TestCase(unittest.TestCase):
+    files = list()
     log_file = None
     max_examples = -1
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
@@ -61,7 +62,12 @@ class TestCase(unittest.TestCase):
             self._logger.debug(f"{message}\n")
 
     def get_csv_files(self) -> Iterator[str]:
-        for file in glob.glob(os.path.join(TestCase.root_path, "[0-9]" * 4, "**", "*"), recursive=True):
+        if TestCase.files:
+            file_list = [os.path.join(TestCase.root_path, x) for x in TestCase.files]
+        else:
+            file_list = glob.glob(os.path.join(TestCase.root_path, "[0-9]" * 4, "**", "*"), recursive=True)
+
+        for file in file_list:
             if file.lower().endswith(".csv"):
                 short_path = os.path.relpath(file, start=TestCase.root_path)
                 year = pathlib.Path(short_path).parts[0]

--- a/run_tests.py
+++ b/run_tests.py
@@ -9,6 +9,8 @@ if __name__ == "__main__":
     parser.add_argument("test", choices=["file_format", "duplicate_entries", "missing_values",
                                          "vote_breakdown_totals"], type=str, help="the data test to run")
     parser.add_argument("root_path", type=str, help="the absolute path to the repository containing files to test")
+    parser.add_argument("--files", type=str, metavar="FILE", nargs="+", help="limit the tests to these specific files, "
+                                                                             "specified relative to the root path")
     parser.add_argument("--group-failures", action="store_true",
                         help="group the failures by year in the console output using the GitHub Actions group and "
                              "endgroup workflow commands")
@@ -20,6 +22,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     TestCase.root_path = args.root_path
+    TestCase.files = args.files
     TestCase.log_file = args.log_file
     TestCase.max_examples = args.max_examples
 

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -1,4 +1,5 @@
 import csv
+import glob
 import os
 import re
 import subprocess
@@ -218,9 +219,8 @@ class RunTestsTest(unittest.TestCase):
 
     def run_test(self, test, root_path, *args):
         command = ["python", os.path.join(RunTestsTest.root_path, "run_tests.py"), test,
-                   f"--log-file={self.log_file.name}"]
+                   f"--log-file={self.log_file.name}", root_path]
         command.extend(args)
-        command.append(root_path)
         completed_process = subprocess.run(command, capture_output=True)
         return completed_process
 
@@ -246,15 +246,28 @@ class RunTestsTest(unittest.TestCase):
         self.verify_success("missing_values")
         self.verify_failure("missing_values", "1 rows.*missing.*county", [4])
 
+    def test_specific_files(self):
+        good_files = [
+            os.path.relpath(f, self.good_data_dir.name)
+            for f in glob.glob(os.path.join(self.root_path,self.good_data_dir.name, "**", "*"))
+        ]
+        self.verify_success("missing_values", "--files", f"{' '.join(good_files)}")
+
+        bad_files = [
+            os.path.relpath(f, self.bad_data_dir.name)
+            for f in glob.glob(os.path.join(self.root_path, self.bad_data_dir.name, "**", "*"))
+        ]
+        self.verify_failure("missing_values", "1 rows.*missing.*county", [4], "--files", f"{' '.join(bad_files)}")
+
     def test_vote_breakdown_totals(self):
         self.verify_success("vote_breakdown_totals")
         self.verify_failure("vote_breakdown_totals", "1 rows.*absentee.*", [5])
 
-    def verify_success(self, test):
-        self.assertEqual(0, self.run_test(test, self.good_data_dir.name).returncode)
+    def verify_success(self, test, *args):
+        self.assertEqual(0, self.run_test(test, self.good_data_dir.name, *args).returncode)
 
-    def verify_failure(self, test, expected_message, expected_rows):
-        self.assertEqual(1, self.run_test(test, self.bad_data_dir.name).returncode)
+    def verify_failure(self, test, expected_message, expected_rows, *args):
+        self.assertEqual(1, self.run_test(test, self.bad_data_dir.name, *args).returncode)
 
         with open(self.log_file.name, "r") as log_file:
             log_file_contents = "\n".join(log_file.readlines())

--- a/tests/test_data_tests.py
+++ b/tests/test_data_tests.py
@@ -231,6 +231,10 @@ class RunTestsTest(unittest.TestCase):
     def test_group_failures(self):
         completed_process = self.run_test("duplicate_entries", self.bad_data_dir.name)
         ungrouped_output = completed_process.stderr.decode()
+
+        # Skip success (.) or failure (F) indicators.
+        ungrouped_output = ungrouped_output[ungrouped_output.find("\n"):]
+
         self.assertNotRegex(ungrouped_output, "::group::")
         self.assertNotRegex(ungrouped_output, "::endgroup::")
 

--- a/tests/test_format_tests.py
+++ b/tests/test_format_tests.py
@@ -404,6 +404,10 @@ class RunTestsTest(unittest.TestCase):
     def test_group_failures(self):
         completed_process = self.run_test(self.bad_data_dir.name)
         ungrouped_output = completed_process.stderr.decode()
+
+        # Skip success (.) or failure (F) indicators.
+        ungrouped_output = ungrouped_output[ungrouped_output.find("\n"):]
+
         self.assertNotRegex(ungrouped_output, "::group::")
         self.assertNotRegex(ungrouped_output, "::endgroup::")
 


### PR DESCRIPTION
This adds an option to limit the tests to specific files.  This will allow us to create new workflows that
1. Test just the files that were added in a pull request.
2. Automatically comment on a pull request to raise potential issues in the new files.

These will hopefully make it easier for us to catch and address issues earlier upon submission rather than later.  The submitter may have more insight about the data than someone examining the data afterwards.

A future direction of improvement can be to run the tests on modified files as well, but that will require a bit more work.

