### PR TITLE
Add option to truncate log file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A collection of tests to validate the contents of OpenElections data files.
 
 ## Usage
 ```
-usage: run_tests.py [-h] [--files FILE [FILE ...]] [--group-failures] [--log-file LOG_FILE] [--max-examples N] {file_format,duplicate_entries,missing_values,vote_breakdown_totals} root_path
+usage: run_tests.py [-h] [--files FILE [FILE ...]] [--group-failures] [--log-file LOG_FILE] [--truncate-log-file] [--max-examples N] {file_format,duplicate_entries,missing_values,vote_breakdown_totals} root_path
 
 positional arguments:
   {file_format,duplicate_entries,missing_values,vote_breakdown_totals}
@@ -18,6 +18,7 @@ options:
                         limit the tests to these specific files, specified relative to the root path
   --group-failures      group the failures by year in the console output using the GitHub Actions group and endgroup workflow commands
   --log-file LOG_FILE   the absolute path to a file that the full failure messages will be written to
+  --truncate-log-file   truncate the entries in the log file according to the --max-examples option.
   --max-examples N      the maximum number of failing rows to print to the console. If a negative value is provided, all failures will be printed.
 ```
 

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -40,6 +40,7 @@ class TestCase(unittest.TestCase):
     log_file = None
     max_examples = -1
     root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+    truncate_log_file = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -51,7 +52,7 @@ class TestCase(unittest.TestCase):
 
     def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
         if not result:
-            self._log_failure(description, full_message)
+            self._log_failure(description, short_message if self.truncate_log_file else full_message)
         self.assertTrue(result, short_message)
 
     def _log_failure(self, description: str, message: str):

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -50,10 +50,10 @@ class TestCase(unittest.TestCase):
         else:
             self._logger = TestCase._get_logger(type(self).__name__, TestCase.log_file)
 
-    def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
+    def _assertTrue(self, result: bool, description: str, console_message: str, log_message: str):
         if not result:
-            self._log_failure(description, full_message)
-        self.assertTrue(result, short_message)
+            self._log_failure(description, log_message)
+        self.assertTrue(result, console_message)
 
     def _log_failure(self, description: str, message: str):
         if self._logger is not None:
@@ -100,9 +100,9 @@ class DuplicateEntriesTest(TestCase):
                     for row in reader:
                         data_test.test(row)
 
-                short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
-                full_message = data_test.get_failure_message(max_examples=log_file_max_examples)
-                self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
+                console_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
+                log_message = data_test.get_failure_message(max_examples=log_file_max_examples)
+                self._assertTrue(data_test.passed, f"{self} [{short_path}]", console_message, log_message)
 
 
 class FileFormatTests(TestCase):
@@ -143,19 +143,19 @@ class FileFormatTests(TestCase):
                             test.test(row)
 
                 passed = True
-                short_message = ""
-                full_message = ""
+                console_message = ""
+                log_message = ""
                 is_first_message = True
                 for test in sorted(tests, key=lambda x: type(x).__name__):
                     if not test.passed:
                         passed = False
-                        short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
+                        console_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
-                            full_message += "\n\n"
-                        full_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
+                            log_message += "\n\n"
+                        log_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
                         is_first_message = False
 
-                self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
+                self._assertTrue(passed, f"{self} [{short_path}]", console_message, log_message)
 
 
 class MissingValuesTest(TestCase):
@@ -180,19 +180,19 @@ class MissingValuesTest(TestCase):
                             test.test(row)
 
                 passed = True
-                short_message = ""
-                full_message = ""
+                console_message = ""
+                log_message = ""
                 is_first_message = True
                 for test in tests:
                     if not test.passed:
                         passed = False
-                        short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
+                        console_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
-                            full_message += "\n\n"
-                        full_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
+                            log_message += "\n\n"
+                        log_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
                         is_first_message = False
 
-                self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
+                self._assertTrue(passed, f"{self} [{short_path}]", console_message, log_message)
 
 
 class VoteBreakdownTotalsTest(TestCase):
@@ -209,6 +209,6 @@ class VoteBreakdownTotalsTest(TestCase):
                     for row in reader:
                         data_test.test(row)
 
-                short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
-                full_message = data_test.get_failure_message(max_examples=log_file_max_examples)
-                self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
+                console_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
+                log_message = data_test.get_failure_message(max_examples=log_file_max_examples)
+                self._assertTrue(data_test.passed, f"{self} [{short_path}]", console_message, log_message)

--- a/data_tests/test_data.py
+++ b/data_tests/test_data.py
@@ -52,7 +52,7 @@ class TestCase(unittest.TestCase):
 
     def _assertTrue(self, result: bool, description: str, short_message: str, full_message: str):
         if not result:
-            self._log_failure(description, short_message if self.truncate_log_file else full_message)
+            self._log_failure(description, full_message)
         self.assertTrue(result, short_message)
 
     def _log_failure(self, description: str, message: str):
@@ -88,6 +88,7 @@ class TestCase(unittest.TestCase):
 
 class DuplicateEntriesTest(TestCase):
     def test_duplicate_entries(self):
+        log_file_max_examples = TestCase.max_examples if TestCase.truncate_log_file else -1
         for csv_file, short_path, year in self.get_csv_files():
             with self.subTest(msg=f"{short_path}", group=year):
                 with open(csv_file, "r") as csv_data:
@@ -100,12 +101,13 @@ class DuplicateEntriesTest(TestCase):
                         data_test.test(row)
 
                 short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
-                full_message = data_test.get_failure_message()
+                full_message = data_test.get_failure_message(max_examples=log_file_max_examples)
                 self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)
 
 
 class FileFormatTests(TestCase):
     def test_format(self):
+        log_file_max_examples = TestCase.max_examples if TestCase.truncate_log_file else -1
         for csv_file, short_path, year in self.get_csv_files():
             tests = set()
 
@@ -150,7 +152,7 @@ class FileFormatTests(TestCase):
                         short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
                             full_message += "\n\n"
-                        full_message += f"* {test.get_failure_message()}"
+                        full_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
                         is_first_message = False
 
                 self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
@@ -158,6 +160,7 @@ class FileFormatTests(TestCase):
 
 class MissingValuesTest(TestCase):
     def test_missing_values(self):
+        log_file_max_examples = TestCase.max_examples if TestCase.truncate_log_file else -1
         for csv_file, short_path, year in self.get_csv_files():
             with self.subTest(msg=f"{short_path}", group=year):
                 tests = []
@@ -186,7 +189,7 @@ class MissingValuesTest(TestCase):
                         short_message += f"\n\n* {test.get_failure_message(max_examples=TestCase.max_examples)}"
                         if not is_first_message:
                             full_message += "\n\n"
-                        full_message += f"* {test.get_failure_message()}"
+                        full_message += f"* {test.get_failure_message(max_examples=log_file_max_examples)}"
                         is_first_message = False
 
                 self._assertTrue(passed, f"{self} [{short_path}]", short_message, full_message)
@@ -194,6 +197,7 @@ class MissingValuesTest(TestCase):
 
 class VoteBreakdownTotalsTest(TestCase):
     def test_vote_method_totals(self):
+        log_file_max_examples = TestCase.max_examples if TestCase.truncate_log_file else -1
         for csv_file, short_path, year in self.get_csv_files():
             with self.subTest(msg=f"{short_path}", group=year):
                 with open(csv_file, "r") as csv_data:
@@ -206,5 +210,5 @@ class VoteBreakdownTotalsTest(TestCase):
                         data_test.test(row)
 
                 short_message = data_test.get_failure_message(max_examples=TestCase.max_examples)
-                full_message = data_test.get_failure_message()
+                full_message = data_test.get_failure_message(max_examples=log_file_max_examples)
                 self._assertTrue(data_test.passed, f"{self} [{short_path}]", short_message, full_message)

--- a/run_tests.py
+++ b/run_tests.py
@@ -16,6 +16,8 @@ if __name__ == "__main__":
                              "endgroup workflow commands")
     parser.add_argument("--log-file", type=str, help="the absolute path to a file that the full failure messages will "
                                                      "be written to")
+    parser.add_argument("--truncate-log-file", action="store_true",
+                        help="truncate the entries in the log file according to the --max-examples option.")
     parser.add_argument("--max-examples", type=int, default=10, metavar="N",
                         help="the maximum number of failing rows to print to the console. If a negative value is "
                              "provided, all failures will be printed.")
@@ -25,6 +27,7 @@ if __name__ == "__main__":
     TestCase.files = args.files
     TestCase.log_file = args.log_file
     TestCase.max_examples = args.max_examples
+    TestCase.truncate_log_file = args.truncate_log_file
 
     test_class = None
     if args.test == "file_format":


### PR DESCRIPTION
This adds an option to truncate the log file according to the `--max-examples` option.  This will help to limit the length of the automatic pull request comments that will be created to notify the submitter of errors in newly added files.

In doing so, we renamed some local variables to better capture their usage.